### PR TITLE
Support for SushiSwap

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=10.15.0 <=12.16.1"

--- a/src/lib/dexs/kyber.ts
+++ b/src/lib/dexs/kyber.ts
@@ -1,5 +1,5 @@
-const kyberStorageABI = require( "../../abi/kyberStorage.json");
-const kyberHintABI = require( "../../abi/kyberHint.json");
+import * as kyberStorageABI from "../../abi/kyberStorage.json";
+import * as kyberHintABI from "../../abi/kyberHint.json";
 
 import {
   Address

--- a/src/lib/transaction-builder.ts
+++ b/src/lib/transaction-builder.ts
@@ -208,6 +208,7 @@ export class TransactionBuilder {
         );
 
       case "uniswapv2":
+      case "sushiswap":
         return web3Coder.encodeParameter(
           {
             "ParentStruct": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,10 +83,10 @@ export class User {
 }
 
 export enum EXCHANGES {
-  KYBER = "Kyber",
   UNISWAP = "Uniswap",
+  KYBER = "Kyber",
   BANCOR = "Bancor",
-  Oasis = "Oasis",
+  OASIS = "Oasis",
   COMPOUND = "Compound",
   BZX = "Fulcrum",
   ZEROX = "0x",
@@ -94,6 +94,15 @@ export enum EXCHANGES {
   CHAI = "Chai",
   PARASWAPPOOL = "ParaSwapPool",
   AAVE = "Aave",
+  MULTIPATH = "MultiPath",
+  CURVE = "Curve",
+  BDAI = "BDai",
+  IDLE = "idle",
+  WETH = "Weth",
+  BETH = "Beth",
+  UNISWAPV2 = "UniswapV2",
+  BALANCER = "Balancer",
+  SUSHISWAP = "SushiSwap",
 }
 
 export type RateOptions = {


### PR DESCRIPTION
Fix to allow use as a Git dependency (use 'prepare' script instead of 'prepublishOnly'), revert fix to Kyber imports (using 'require' doesn't copy JSON to build folder, so have to use 'import') and add support for SushiSwap (updated EXCHANGES list).