### PR TITLE
Don't publish extra files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,7 @@ tsconfig.json
 jest.config.js
 .idea
 .env
+.editorconfig
+.prettierrc
+apiary.apib
+.vscode


### PR DESCRIPTION
Adds  files to `.npmignore` so they don't get published

```sh
.editorconfig
.prettierrc
apiary.apib
```

You can test by running `npm pack` and checking the resulting tarball