### PR TITLE
Fix types in tests

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../src/types';
 import { NULL_ADDRESS } from '../src/lib/transaction-builder';
 import { SwapSide } from '../src/constants';
+import { assert } from 'ts-essentials';
 const erc20abi = require('../src/abi/erc20.json');
 
 dotenv.config();
@@ -219,6 +220,9 @@ describe('ParaSwap SDK', () => {
     const srcToken = new Token(ETH, 18, 'DAI');
     const destToken = new Token(DAI, 18, 'KNC');
 
+    assert(srcToken.symbol, 'token should have a symbol');
+    assert(destToken.symbol, 'token should have a symbol');
+
     const ratesOrError = await paraSwap.getRate(
       srcToken.symbol,
       destToken.symbol,
@@ -242,8 +246,6 @@ describe('ParaSwap SDK', () => {
       referrer,
       gasPrice,
       receiver,
-      '0',
-      { ignoreChecks: true },
     );
     expect(typeof transaction).toBe('object');
   });


### PR DESCRIPTION
The tests still expect `token.symbol` to not be optional.
```sh
tests/index.test.ts:228:7 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
      Type 'undefined' is not assignable to type 'string'.

    228       destToken.symbol
```
One workaround is to assert them, like in this PR.

But you may want to rework `getRate` function signature (please don't) or make `token.symbol` required again

Tests still break for me without proper env variables. I assume there must be some local testnet setup (ganache?) or a specific account to test against rposten or similar?
Anyway, would be nice to rewrite `test` script to make it self-sufficent (spin up ganache if necessary)