### PR TITLE
Add spender to OptimalRates type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,7 @@ type OptimalRates = {
   fromUSD?: NumberAsString;
   toUSD?: NumberAsString;
   side: SwapSide;
+  spender?: Address;
   details?: {
     routes?: string[];
     tokenFrom: string;


### PR DESCRIPTION
Upon calling the `getRate()` method, the returned object contains the missing field `spender`.

![image](https://user-images.githubusercontent.com/33292765/118659610-c24eac00-b7ed-11eb-99ad-1ffca732e240.png)
