### PR TITLE
Feat/ignoreGas check

### DIFF
--- a/src/paraswap.ts
+++ b/src/paraswap.ts
@@ -324,6 +324,10 @@ export class ParaSwap {
       augustusVersion,
     );
 
+    const ignoreGasCheck = !!(
+      options.ignoreChecks || options.ignoreGasEstimate
+    );
+
     return transaction.buildTransaction(
       srcToken,
       destToken,
@@ -335,7 +339,7 @@ export class ParaSwap {
       referrerIndex,
       gasPrice,
       receiver,
-      !!options.ignoreChecks,
+      ignoreGasCheck,
       augustusVersion,
       !!options.onlyParams,
       !!options.useReduxToken,

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,6 +297,7 @@ type TransactionData = {
 
 type BuildOptions = {
   ignoreChecks?: boolean;
+  ignoreGasEstimate?: boolean;
   onlyParams?: boolean;
   simple?: boolean;
   gasPrice?: PriceString;


### PR DESCRIPTION
- Brings `BuildOptions `type in line with paraswap/paraswap-api#138
- `TransactionBuilder.buildTransaction` only performs gasCheck, so passing `ignoreChecks || ignoreGasEstimate` to it