### PR TITLE
feat: Provide full data in APIError response

### DIFF
--- a/src/paraswap.ts
+++ b/src/paraswap.ts
@@ -58,7 +58,7 @@ export class ParaSwap {
   private handleAPIError(e: AxiosError): APIError {
     if (e.response) {
       const { data, status } = e.response!;
-      return { status, message: data.error };
+      return { status, message: data.error, data };
     }
     return new Error(e.message);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ type Allowance = {
 type APIError = {
   message: string;
   status?: number;
+  data?: any;
 };
 
 type Transaction = {


### PR DESCRIPTION
When you get `ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT` error, it can be interesting to see the `priceRoute` that is also returned by the API, so put all the `data` into the `APIError` to make this available.