### PR TITLE
Sdk refactoring -- generic Contract caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,113 @@ yarn add @paraswap/sdk
 
 ## Using ParaSwap SDK
 
-### Import the necessary functions
+There are multiple ways to use ParaSwap SDK, ranging from a simple construct-and-use approach to a fully composable _bring what you need_ approach which allows for advanced tree-shaking and minimizes bundle size.
+
+### Simple SDK
+
+Can be created by providing `network` and either `axios` or `window.fetch` (or alternative `fetch` implementation). The resulting SDK will be able to use all methods that query the API.
+
+```ts
+  import { constructSimpleSDK } from '@paraswap/sdk';
+  import axios from 'axios';
+
+  // construct minimal SDK with fetcher only
+  const paraSwapMin = constructSimpleSDK({network: 1, axios});
+  // or
+  const paraSwapMin = constructSimpleSDK({network: 1, fetch: window.fetch});
+
+  const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+  const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+  async function swapExample() {
+    const signer: JsonRpcSigner = ...
+    const senderAddress = signer.address;
+
+    const priceRoute = await paraSwapMin.getRate({
+      srcToken: ETH,
+      destToken: DAI,
+      amount: srcAmount,
+      userAddress: senderAddress,
+      side: SwapSide.SELL,
+    });
+
+    const txParams = await paraSwapMin.buildTx(
+      {
+        srcToken,
+        destToken,
+        srcAmount,
+        destAmount,
+        priceRoute,
+        userAddress: senderAddress,
+        partner: referrer,
+      },
+      { ignoreChecks: true }
+    );
+
+    const transaction = {
+      ...txParams,
+      gasPrice: '0x' + new BigNumber(txParams.gasPrice).toString(16),
+      gasLimit: '0x' + new BigNumber(5000000).toString(16),
+      value: '0x' + new BigNumber(txParams.value).toString(16),
+    };
+
+    const txr = await signer.sendTransaction(transaction);
+  }
+
+
+  async function approveTokenYourselfExample() {
+    const TransferProxy = await paraSwapMin.getSpender();
+
+    const DAI_CONTRACT = new ethers.Contract(DAI, ERC20_ABI, ethersSignerOrProvider);
+
+    const tx = await DAI_CONTRACT.approve(TransferProxy, amountInWei);
+
+    const txReceipt = await tx.wait(1);
+  }
+
+```
+
+If optional `providerOptions` is provided as the second parameter, then the resulting SDK will also be able to approve Tokens for swap.
+
+```ts
+  // 
+  // with ethers.js
+  const providerOptionsEther = {
+    ethersProviderOrSigner: provider, // JsonRpcProvider
+    EthersContract: ethers.Contract,
+    account: senderAddress,
+  };
+
+  // or with web3.js
+  const providerOptionsWeb3 = {
+    web3, // new Web3(...) instance
+    account: senderAddress,
+  };
+
+  const paraSwap = constructSimpleSDK({network: 1, axios}, providerOptionsEther);
+
+  async function approveTokenExample() {
+    const txHash = await paraSwap.approveToken(amountInWei, DAI);
+
+    // await tx somehow
+    await provider.waitForTransaction(txHash);
+  }
+```
+
+### Composed SDK
+Import the necessary functions
 ```typescript
 import { constructSDK, constructAxiosFetcher, constructEthersContractCaller } from '@paraswap/sdk';
 ```
 ### Construct the ParaSwap object
 
 ```typescript
-const signer = ethers.Wallet.fromMnmemonic('__your_mnemonic__') // or any other signer/provider 
-const account = '__signer_address__'
+const signer = ethers.Wallet.fromMnmemonic('__your_mnemonic__'); // or any other signer/provider 
+const account = '__signer_address__';
 
 const contractCaller = constructEthersContractCaller({
-  providerOrSigner: signer,
-  Contract: ethers.Contract,
+  ethersProviderOrSigner: signer,
+  EthersContract: ethers.Contract,
 }, account); // alternatively constructWeb3ContractCaller
 const fetcher = constructAxiosFetcher(axios); // alternatively constructFetchFetcher
 
@@ -49,7 +143,16 @@ const paraswap = constructSDK({
 ### To approve ParaSwap contracts to swap an ERC20 token
 
 ```typescript
-const txHash = await paraSwap.approveToken(amount, tokenAddress);
+// if created with constructEthersContractCaller
+const contractTx: ContractTransaction = await paraSwap.approveToken(amount, tokenAddress);
+const txReceipt = await contractTx.wait();
+
+// if created with constructWeb3ContractCaller
+const unpromiEvent: Web3UnpromiEvent = await paraSwap.approveToken(amount, tokenAddress);
+const txReceipt = await new Promise<Web3TransactionReceipt>((resolve, reject) => {
+  unpromiEvent.once('receipt', resolve);
+  unpromiEvent.once('error', reject);
+})
 ```
 
 ### To get the rate of a token pair
@@ -58,8 +161,8 @@ const txHash = await paraSwap.approveToken(amount, tokenAddress);
 const srcToken = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'; // ETH
 const destToken = '0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5'; // PSP
 const srcAmount = '1000000000000000000'; //The source amount multiplied by its decimals: 10 ** 18 here
-const srcDecimals = 18
-const destDecimals = 18
+const srcDecimals = 18;
+const destDecimals = 18;
 
 const priceRoute = await paraSwap.getRate(
   {
@@ -78,15 +181,15 @@ Where priceRoute contains the rate and the distribution among exchanges, checkou
 
 ```typescript
 const srcToken = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-const srcDecimals = 18
+const srcDecimals = 18;
 const srcAmount = '1000000000000000000'; // The source amount multiplied by its decimals
 const destToken = '0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5';
-const destDecimals = 18
-const destAmount = priceRoute.destAmount // price route being output of paraSwap.getRate()
+const destDecimals = 18;
+const destAmount = priceRoute.destAmount; // price route being output of paraSwap.getRate()
 const senderAddress = '__sender_address__'; // mandatory
 const receiver = '__receiver_address__'; // optional: for swap and transfer
-const partnerAddress = '__fee_receiver_address__' // optional: for permission-less monetization
-const partnerFeeBps = 50 // optional: fee in base point, for permission-less monetization
+const partnerAddress = '__fee_receiver_address__'; // optional: for permission-less monetization
+const partnerFeeBps = 50; // optional: fee in base point, for permission-less monetization
 
 
 const txParams = await paraSwap.buildTx(
@@ -120,14 +223,14 @@ e.g. for only getting rates and allowances:
 ```typescript
 import { constructPartialSDK, constructFetchFetcher, constructGetRate, constructGetBalances } from '@paraswap/sdk';
 
-const fetcher = constructFetchFetcher(window.fetch)
+const fetcher = constructFetchFetcher(window.fetch);
 
 const minParaSwap = constructPartialSDK({
   network: 1,
   fetcher,
-}, constructGetRate, constructGetBalances)
+}, constructGetRate, constructGetBalances);
 
-const priceRoute = await minParaSwap.getRate(params)
+const priceRoute = await minParaSwap.getRate(params);
 const allowance = await minParaSwap.getAllowance(userAddress, tokenAddress);
 ```
 
@@ -135,12 +238,12 @@ const allowance = await minParaSwap.getAllowance(userAddress, tokenAddress);
 The `ParaSwap` class is exposed for backwards compatibility with previous versions of the SDK.
 
 ```typescript
-import { ParaSwap } from '@paraswap/sdk'
-import axios from 'axios'
-import Web3 from 'web3'
+import { ParaSwap } from '@paraswap/sdk';
+import axios from 'axios';
+import Web3 from 'web3';
 
-const web3Provider = new Web3(window.ethereum)
-const account = '__user_address__'
+const web3Provider = new Web3(window.ethereum);
+const account = '__user_address__';
 
 const paraswap = new ParaSwap(
   1, 
@@ -149,14 +252,14 @@ const paraswap = new ParaSwap(
   undefined, 
   account, 
   axios
-)
+);
 
 ```
 
 By analogy to ```constructPartialSDK```, you can leverage a lightweight version of the sdk for fetching only.
 
 ```typescript
-import { ParaSwap } from '@paraswap/sdk'
+import { ParaSwap } from '@paraswap/sdk';
 
 const paraswap = new ParaSwap(
   1, 
@@ -166,7 +269,7 @@ const paraswap = new ParaSwap(
   undefined, 
   undefined,
   window.fetch
-)
+);
 
 ```
 

--- a/src/approve.ts
+++ b/src/approve.ts
@@ -1,6 +1,6 @@
 import { constructGetSpender } from './spender';
-import { Address, PriceString } from './token';
-import { ConstructProviderFetchInput, TxSendOverrides } from './types';
+import type { Address, PriceString } from './token';
+import type { ConstructProviderFetchInput, TxSendOverrides } from './types';
 
 type ApproveToken<T> = (
   amount: PriceString,

--- a/src/approve.ts
+++ b/src/approve.ts
@@ -65,7 +65,6 @@ export const constructApproveToken = <T>(
       contractMethod: 'approve',
       args: [spender, amount],
       overrides,
-      static: false,
     });
 
     return res;

--- a/src/examples/partial.ts
+++ b/src/examples/partial.ts
@@ -3,8 +3,8 @@ import axios from 'axios';
 import { ethers } from 'ethers';
 import {
   constructPartialSDK,
-  constructFullSDK,
   constructGetAdapters,
+  constructApproveToken,
   constructEthersContractCaller,
   constructAxiosFetcher,
 } from '..';
@@ -17,23 +17,18 @@ const contractCaller = constructEthersContractCaller({
   EthersContract: ethers.Contract,
 });
 
-const paraswap = constructFullSDK({
-  apiURL: '',
-  network: 1,
-  fetcher,
-  contractCaller,
-});
-
-const res = paraswap.getAdapters({ type: 'list', namesOnly: false });
-
-// type Promise<ContractTransaction>
-const txResponse = paraswap.approveToken('1', '0x...');
-// type Promise<ContractTransaction[]>
-const txResponses = paraswap.approveTokenBulk('1', ['0x...']);
-
+// type AdaptersFunctions & ApproveTokenFunctions<ethers.ContractTransaction>
 const part1 = constructPartialSDK(
-  { apiURL: '', network: 1, fetcher },
-  constructGetAdapters
+  {
+    network: 1,
+    fetcher,
+    contractCaller,
+  },
+  constructGetAdapters,
+  constructApproveToken
 );
 
+// type Promise<AdaptersAsObject>
 const res1 = part1.getAdapters({ type: 'object' });
+// type Promise<ethers.ContractTransaction>
+const res2 = part1.approveToken('123', '0x...');

--- a/src/examples/sdk.ts
+++ b/src/examples/sdk.ts
@@ -27,6 +27,8 @@ const res = paraswap.getAdapters({ type: 'list', namesOnly: false });
 
 // type ContractTransaction
 const txResponse = paraswap.approveToken('1', '0x...');
+// type ContractTransaction[]
+const txResponses = paraswap.approveTokenBulk('1', ['0x...']);
 
 const part1 = constructPartialSDK(
   { apiURL: '', network: 1, fetcher },

--- a/src/examples/sdk.ts
+++ b/src/examples/sdk.ts
@@ -25,6 +25,9 @@ const paraswap = constructSDK({
 
 const res = paraswap.getAdapters({ type: 'list', namesOnly: false });
 
+// type ContractTransaction
+const txResponse = paraswap.approveToken('1', '0x...');
+
 const part1 = constructPartialSDK(
   { apiURL: '', network: 1, fetcher },
   constructGetAdapters

--- a/src/examples/simple.ts
+++ b/src/examples/simple.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import axios from 'axios';
+import { ethers } from 'ethers';
+import { constructSimpleSDK, SwapSide } from '..';
+
+// only methods that fetch from API
+const simpleFetchOnlySDK = constructSimpleSDK({ network: 1, axios });
+
+const account = '0x...';
+
+// type Promise<OptimalRate>
+const rateRes = simpleFetchOnlySDK.getRate({
+  srcToken: '0x...',
+  destToken: '0x...',
+  amount: '1000000000000',
+  userAddress: account,
+  side: SwapSide.SELL,
+});
+
+const provider = ethers.getDefaultProvider(1);
+const providerOptions = {
+  ethersProviderOrSigner: provider,
+  EthersContract: ethers.Contract,
+  account,
+};
+
+const SDKwithApprove = constructSimpleSDK(
+  { network: 1, axios },
+  providerOptions
+);
+
+// type Promise<TxHash>
+const approveTxHash = SDKwithApprove.approveToken('1000000000000', '0x...');

--- a/src/examples/web3.ts
+++ b/src/examples/web3.ts
@@ -1,21 +1,24 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import axios from 'axios';
 import Web3 from 'web3';
-import { constructSDK } from '..';
-import { constructAxiosFetcher } from '../helpers';
-import { constructContractCaller } from '../helpers/web3';
+import {
+  constructFullSDK,
+  constructAxiosFetcher,
+  constructWeb3ContractCaller,
+} from '..';
 
 const fetcher = constructAxiosFetcher(axios);
 const web3 = new Web3(Web3.givenProvider);
-const contractCaller = constructContractCaller(web3);
+const contractCaller = constructWeb3ContractCaller(web3);
 
-const paraswap = constructSDK({
+const paraswap = constructFullSDK({
   network: 1,
   fetcher,
   contractCaller,
 });
 
 async function main() {
+  // type Web3UnpromiEvent
   const eventfulTxResponse = await paraswap.approveToken(
     '1000000000000000000',
     '0xcafe001067cDEF266AfB7Eb5A286dCFD277f3dE5'

--- a/src/examples/web3.ts
+++ b/src/examples/web3.ts
@@ -16,12 +16,14 @@ const paraswap = constructSDK({
 });
 
 async function main() {
-  const txHash = await paraswap.approveToken(
+  const eventfulTxResponse = await paraswap.approveToken(
     '1000000000000000000',
     '0xcafe001067cDEF266AfB7Eb5A286dCFD277f3dE5'
   );
 
-  console.log('watch for tx', txHash);
+  eventfulTxResponse.once('transactionHash', (txHash) =>
+    console.log('watch for tx', txHash)
+  );
 }
 
 main();

--- a/src/helpers/ethers.ts
+++ b/src/helpers/ethers.ts
@@ -95,9 +95,7 @@ export const constructContractCaller = (
       txOverrides
     );
 
-    // returns tx hash
     return txResponse;
-    // @TODO maybe better return the whole txResponse for versatility
   };
 
   return { staticCall, transactCall };

--- a/src/helpers/fetchers/axios.ts
+++ b/src/helpers/fetchers/axios.ts
@@ -1,9 +1,9 @@
-import { FetcherFunction } from '../types';
-import type Axios from 'axios';
-import { FetcherError } from './misc';
+import type { FetcherFunction } from '../../types';
+import type AxiosStatic from 'axios';
+import { FetcherError } from '../misc';
 
 export const constructFetcher =
-  (axios: typeof Axios): FetcherFunction =>
+  (axios: typeof AxiosStatic): FetcherFunction =>
   async (params) => {
     try {
       const { data } = await axios.request(params);

--- a/src/helpers/fetchers/fetch.ts
+++ b/src/helpers/fetchers/fetch.ts
@@ -1,5 +1,5 @@
-import { FetcherFunction } from '../types';
-import { FetcherError } from './misc';
+import type { FetcherFunction } from '../../types';
+import { FetcherError } from '../misc';
 
 // @TODO may not work with node-fetch
 type Fetch = typeof fetch;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,5 +1,11 @@
-export { constructFetcher as constructAxiosFetcher } from './axios';
-export { constructFetcher as constructFetchFetcher } from './fetch';
-export { constructContractCaller as constructEthersContractCaller } from './ethers';
-export { constructContractCaller as constructWeb3ContractCaller } from './web3';
+export { constructFetcher as constructAxiosFetcher } from './fetchers/axios';
+export { constructFetcher as constructFetchFetcher } from './fetchers/fetch';
+export {
+  constructContractCaller as constructEthersContractCaller,
+  EthersProviderDeps,
+} from './providers/ethers';
+export {
+  constructContractCaller as constructWeb3ContractCaller,
+  Web3UnpromiEvent,
+} from './providers/web3';
 export { isFetcherError } from './misc';

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,38 +1,67 @@
 import type {
-  Contract,
-  ContractFunction,
-  PopulatedTransaction,
-  BigNumber,
+  Contract as EthersContract,
+  ContractFunction as EthersContractFunction,
+  PopulatedTransaction as EthersPopulatedTransaction,
+  BigNumber as EthersBigNumber,
 } from 'ethers';
+import type {
+  ContractSendMethod as Web3ContractSendMethod,
+  Contract as Web3Contract,
+} from 'web3-eth-contract';
 import { assert } from 'ts-essentials';
 
 import type { AxiosError } from 'axios';
 
-export type ContractWithMethod<T extends string> = Contract & {
-  readonly [method in T]: ContractFunction;
+export type EthersContractWithMethod<T extends string> = EthersContract & {
+  readonly [method in T]: EthersContractFunction;
 } & {
-  readonly functions: { [method in T]: ContractFunction };
+  readonly functions: { [method in T]: EthersContractFunction };
 
-  readonly callStatic: { [method in T]: ContractFunction };
-  readonly estimateGas: { [method in T]: ContractFunction<BigNumber> };
+  readonly callStatic: { [method in T]: EthersContractFunction };
+  readonly estimateGas: {
+    [method in T]: EthersContractFunction<EthersBigNumber>;
+  };
   readonly populateTransaction: {
-    [method in T]: ContractFunction<PopulatedTransaction>;
+    [method in T]: EthersContractFunction<EthersPopulatedTransaction>;
   };
 };
 
-export function contractHasMethods<T extends string>(
-  contract: Contract,
+export function ethersContractHasMethods<T extends string>(
+  contract: EthersContract,
   ...methods: T[]
-): contract is ContractWithMethod<T> {
+): contract is EthersContractWithMethod<T> {
   return methods.every((method) => typeof contract[method] === 'function');
 }
 
-export function assertContractHasMethods<T extends string>(
-  contract: Contract,
+export function assertEthersContractHasMethods<T extends string>(
+  contract: EthersContract,
   ...methods: T[]
-): asserts contract is ContractWithMethod<T> {
+): asserts contract is EthersContractWithMethod<T> {
   assert(
-    contractHasMethods(contract, ...methods),
+    ethersContractHasMethods(contract, ...methods),
+    `Contract must have methods: ${methods.join(', ')}`
+  );
+}
+
+export type Web3ContractWithMethod<T extends string> = Web3Contract & {
+  methods: { [method in T]: Web3ContractSendMethod };
+};
+
+export function web3ContractHasMethods<T extends string>(
+  contract: Web3Contract,
+  ...methods: T[]
+): contract is Web3ContractWithMethod<T> {
+  return methods.every(
+    (method) => typeof contract.methods[method] === 'function'
+  );
+}
+
+export function assertWeb3ContractHasMethods<T extends string>(
+  contract: Web3Contract,
+  ...methods: T[]
+): asserts contract is Web3ContractWithMethod<T> {
+  assert(
+    web3ContractHasMethods(contract, ...methods),
     `Contract must have methods: ${methods.join(', ')}`
   );
 }

--- a/src/helpers/providers/ethers.ts
+++ b/src/helpers/providers/ethers.ts
@@ -4,7 +4,7 @@ import type {
   NoExtraKeysCheck,
   StaticContractCallerFn,
   TransactionContractCallerFn,
-} from '../types';
+} from '../../types';
 import type { JsonRpcProvider, BaseProvider } from '@ethersproject/providers';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type {
@@ -13,16 +13,19 @@ import type {
   CallOverrides,
   ContractTransaction,
 } from '@ethersproject/contracts';
-import { assertContractHasMethods } from '../helpers/misc';
+import { assertEthersContractHasMethods } from '../misc';
 import { assert } from 'ts-essentials';
 
-interface EthersProviderDeps {
-  providerOrSigner: BaseProvider | Signer;
-  Contract: typeof EthersContract; // passing Contract in allows not to include ethers as dependency even when using legacy ParaSwap class
+export interface EthersProviderDeps {
+  ethersProviderOrSigner: BaseProvider | Signer;
+  EthersContract: typeof EthersContract; // passing Contract in allows not to include ethers as dependency even when using legacy ParaSwap class
 }
 
 export const constructContractCaller = (
-  { providerOrSigner, Contract }: EthersProviderDeps,
+  {
+    ethersProviderOrSigner: providerOrSigner,
+    EthersContract: Contract,
+  }: EthersProviderDeps,
   account?: Address
 ): ContractCallerFunctions<ContractTransaction> => {
   const staticCall: StaticContractCallerFn = async (params) => {
@@ -30,7 +33,7 @@ export const constructContractCaller = (
 
     const contract = new Contract(address, abi, providerOrSigner);
 
-    assertContractHasMethods(contract, contractMethod);
+    assertEthersContractHasMethods(contract, contractMethod);
     // drop keys not in CallOverrides
     const { block, gas, ...restOverrides } = overrides;
     // reassign values to keys in CallOverrides
@@ -72,7 +75,7 @@ export const constructContractCaller = (
 
     const contract = new Contract(address, abi, signer);
 
-    assertContractHasMethods(contract, contractMethod);
+    assertEthersContractHasMethods(contract, contractMethod);
     // drop keys not in PayableOverrides
     const { gas, from, ...restOverrides } = overrides;
     // reassign values to keys in PayableOverrides

--- a/src/helpers/providers/web3.ts
+++ b/src/helpers/providers/web3.ts
@@ -3,7 +3,7 @@ import type {
   ContractCallerFunctions,
   StaticContractCallerFn,
   TransactionContractCallerFn,
-} from '../types';
+} from '../../types';
 import type Web3 from 'web3';
 import type { AbiItem } from 'web3-utils';
 import type {
@@ -14,14 +14,14 @@ import type {
 } from 'web3-eth-contract';
 import type { PromiEvent } from 'web3-core';
 import { assert } from 'ts-essentials';
-import { assertContractHasMethods } from './misc';
+import { assertWeb3ContractHasMethods } from '../misc';
 
-export type UnpromiEvent = Pick<PromiEvent<Contract>, 'on' | 'once'>;
+export type Web3UnpromiEvent = Pick<PromiEvent<Contract>, 'on' | 'once'>;
 
 export const constructContractCaller = (
   web3: Web3,
   account?: Address
-): ContractCallerFunctions<UnpromiEvent> => {
+): ContractCallerFunctions<Web3UnpromiEvent> => {
   const staticCall: StaticContractCallerFn = async (params) => {
     assert(web3.currentProvider, 'web3.currentProvider is not set');
 
@@ -32,7 +32,7 @@ export const constructContractCaller = (
       address
     );
 
-    assertContractHasMethods(contract.methods, contractMethod); // FIXME: web3.contract.methods is any and assert works with ethers types
+    assertWeb3ContractHasMethods(contract, contractMethod);
 
     const { block, gas, ...restOverrides } = overrides;
 
@@ -44,7 +44,7 @@ export const constructContractCaller = (
     return contract.methods[contractMethod](...args).call(normalizedOverrides);
   };
 
-  const transactCall: TransactionContractCallerFn<UnpromiEvent> = async (
+  const transactCall: TransactionContractCallerFn<Web3UnpromiEvent> = async (
     params
   ) => {
     assert(web3.currentProvider, 'web3.currentProvider is not set');
@@ -59,7 +59,7 @@ export const constructContractCaller = (
       address
     );
 
-    assertContractHasMethods(contract.methods, contractMethod); // FIXME see up
+    assertWeb3ContractHasMethods(contract, contractMethod);
 
     const { gas, from, ...restOverrides } = overrides;
 
@@ -84,7 +84,7 @@ export const constructContractCaller = (
     // that is await Promise<PromiEvent> = Awaited<PromiEvent> that doesn't have .on|once
     // so that functionality becomes lost
     // transactCall can be made sync, but approve has to be async to await getSpender()
-    const unpromiEvent: UnpromiEvent = {
+    const unpromiEvent: Web3UnpromiEvent = {
       on: promiEvent.on.bind(promiEvent),
       once: promiEvent.once.bind(promiEvent),
     };

--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -1,6 +1,4 @@
 import type { MarkOptional } from 'ts-essentials';
-import { API_URL } from './constants';
-import type { ConstructFetchInput, TokensApiResponse } from './types';
 
 /**
  * @type hex token or account address
@@ -74,31 +72,4 @@ export const constructToken = (tokenProps: ConstructTokenInput): Token => {
     network,
     ...rest,
   };
-};
-
-type GetTokens = (signal?: AbortSignal) => Promise<Token[]>;
-
-export type GetTokensFunctions = {
-  getTokens: GetTokens;
-};
-
-export const constructGetTokens = ({
-  apiURL = API_URL,
-  network,
-  fetcher,
-}: ConstructFetchInput): GetTokensFunctions => {
-  const fetchURL = `${apiURL}/tokens/${network}`;
-
-  const getTokens: GetTokens = async (signal) => {
-    const data = await fetcher<TokensApiResponse>({
-      url: fetchURL,
-      method: 'GET',
-      signal,
-    });
-
-    const tokens = data.tokens.map(constructToken);
-    return tokens;
-  };
-
-  return { getTokens };
 };

--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -1,19 +1,28 @@
-import type { Address, ContractCallerFunction } from '../types';
+import type {
+  Address,
+  ContractCallerFunctions,
+  StaticContractCallerFn,
+  TransactionContractCallerFn,
+} from '../types';
 import type Web3 from 'web3';
 import type { AbiItem } from 'web3-utils';
 import type {
   ContractSendMethod,
   SendOptions,
   CallOptions,
+  Contract,
 } from 'web3-eth-contract';
+import type { PromiEvent } from 'web3-core';
 import { assert } from 'ts-essentials';
 import { assertContractHasMethods } from './misc';
+
+export type UnpromiEvent = Pick<PromiEvent<Contract>, 'on' | 'once'>;
 
 export const constructContractCaller = (
   web3: Web3,
   account?: Address
-): ContractCallerFunction => {
-  const contractCallerFunction: ContractCallerFunction = async (params) => {
+): ContractCallerFunctions<UnpromiEvent> => {
+  const staticCall: StaticContractCallerFn = async (params) => {
     assert(web3.currentProvider, 'web3.currentProvider is not set');
 
     if (params.static) {
@@ -37,6 +46,12 @@ export const constructContractCaller = (
         normalizedOverrides
       );
     }
+  };
+
+  const transactCall: TransactionContractCallerFn<UnpromiEvent> = async (
+    params
+  ) => {
+    assert(web3.currentProvider, 'web3.currentProvider is not set');
 
     // assert(account, 'account must be specified to create a signer');
     // FIXME: how to assert properly if user passed signer
@@ -66,16 +81,20 @@ export const constructContractCaller = (
       ...args
     ) as ContractSendMethod;
 
-    return new Promise<string>((resolve, reject) => {
-      preparedCall.send(normalizedOverrides, (err, transactionHash) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(transactionHash);
-        }
-      });
-    });
+    const promiEvent = preparedCall.send(normalizedOverrides);
+
+    // can't just return promiEvent, because async function returns a Promise<PromiEvent>
+    // and await Promise<PromiEvent> automatically awaits the value of PromiEvent,
+    // that is await Promise<PromiEvent> = Awaited<PromiEvent> that doesn't have .on|once
+    // so that functionality becomes lost
+    // transactCall can be made sync, but approve has to be async to await getSpender()
+    const unpromiEvent: UnpromiEvent = {
+      on: promiEvent.on.bind(promiEvent),
+      once: promiEvent.once.bind(promiEvent),
+    };
+
+    return unpromiEvent;
   };
 
-  return contractCallerFunction;
+  return { staticCall, transactCall };
 };

--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -25,27 +25,23 @@ export const constructContractCaller = (
   const staticCall: StaticContractCallerFn = async (params) => {
     assert(web3.currentProvider, 'web3.currentProvider is not set');
 
-    if (params.static) {
-      const { address, abi, contractMethod, args, overrides } = params;
+    const { address, abi, contractMethod, args, overrides } = params;
 
-      const contract = new web3.eth.Contract(
-        abi as AbiItem[], // FIXME abi types ethers dependant
-        address
-      );
+    const contract = new web3.eth.Contract(
+      abi as AbiItem[], // FIXME abi types ethers dependant
+      address
+    );
 
-      assertContractHasMethods(contract.methods, contractMethod); // FIXME: web3.contract.methods is any and assert works with ethers types
+    assertContractHasMethods(contract.methods, contractMethod); // FIXME: web3.contract.methods is any and assert works with ethers types
 
-      const { block, gas, ...restOverrides } = overrides;
+    const { block, gas, ...restOverrides } = overrides;
 
-      const normalizedOverrides: CallOptions = {
-        ...restOverrides,
-        gas,
-      };
+    const normalizedOverrides: CallOptions = {
+      ...restOverrides,
+      gas,
+    };
 
-      return contract.methods[contractMethod](...args).call(
-        normalizedOverrides
-      );
-    }
+    return contract.methods[contractMethod](...args).call(normalizedOverrides);
   };
 
   const transactCall: TransactionContractCallerFn<UnpromiEvent> = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,39 @@
-import { constructApproveToken, ApproveTokenFunctions } from './approve';
-import { constructGetBalances, GetBalancesFunctions } from './balance';
-import { constructGetSpender, GetSpenderFunctions } from './spender';
-import { constructGetAdapters, AdaptersFunctions } from './adapters';
-import { constructGetRate, GetRateFunctions } from './rates';
 import {
-  constructGetTokens,
-  constructToken,
-  GetTokensFunctions,
-  Token,
-  PriceString,
-} from './token';
-import { BuildTxFunctions, constructBuildTx } from './transaction';
+  constructApproveToken,
+  ApproveTokenFunctions,
+} from './methods/approve';
+import {
+  constructGetBalances,
+  GetBalancesFunctions,
+  isAllowance,
+  Allowance,
+} from './methods/balance';
+import { constructGetSpender, GetSpenderFunctions } from './methods/spender';
+import { constructGetAdapters, GetAdaptersFunctions } from './methods/adapters';
+import { constructGetRate, GetRateFunctions } from './methods/rates';
+import { constructGetTokens, GetTokensFunctions } from './methods/token';
+import { BuildTxFunctions, constructBuildTx } from './methods/transaction';
 import {
   constructEthersContractCaller,
   constructWeb3ContractCaller,
   constructAxiosFetcher,
   constructFetchFetcher,
   isFetcherError,
+  EthersProviderDeps,
 } from './helpers';
 import {
-  ConstructBaseInput,
   ConstructFetchInput,
   ConstructProviderFetchInput,
   Address,
+  AddressOrSymbol,
+  Token,
+  PriceString,
+  TxHash,
+  TxSendOverrides,
 } from './types';
-import { UnionToIntersection } from 'ts-essentials';
 
-export type { TransactionParams } from './transaction';
+export type { TransactionParams } from './methods/transaction';
+export type { Web3UnpromiEvent } from './helpers';
 export * from './constants';
 
 // can import these individually
@@ -42,80 +49,34 @@ export {
   constructWeb3ContractCaller,
   constructAxiosFetcher,
   constructFetchFetcher,
-  constructToken,
   constructGetAdapters,
   constructGetRate,
   isFetcherError,
+  isAllowance,
 };
 
 export type {
+  Allowance,
+  EthersProviderDeps,
   ApproveTokenFunctions,
   GetBalancesFunctions,
   GetSpenderFunctions,
   GetTokensFunctions,
+  GetAdaptersFunctions,
+  GetRateFunctions,
   BuildTxFunctions,
   ConstructFetchInput,
   ConstructProviderFetchInput,
-  AdaptersFunctions as ConstructAdaptersFunctions,
   Token,
   Address,
+  AddressOrSymbol,
   PriceString,
+  TxHash,
+  TxSendOverrides,
 };
 
-export type SDKConfig<TxResponse = any> =
-  ConstructProviderFetchInput<TxResponse> & ConstructFetchInput;
-
-export type AllSDKMethods<TxResponse> = GetBalancesFunctions &
-  GetTokensFunctions &
-  GetSpenderFunctions &
-  ApproveTokenFunctions<TxResponse> &
-  BuildTxFunctions &
-  AdaptersFunctions &
-  GetRateFunctions;
-
-type AnyFunction = (...args: any[]) => any;
-
-type SDKFunction<T extends ConstructBaseInput> = (
-  config: T
-) => Record<string, AnyFunction>;
-
-type IntersectionOfReturns<Funcs extends AnyFunction[]> = UnionToIntersection<
-  ReturnType<Funcs[number]>
->;
-
-export const constructPartialSDK = <
-  T extends ConstructBaseInput,
-  Funcs extends [SDKFunction<T>, ...SDKFunction<T>[]]
->(
-  config: T, // config is auto-inferred to cover the used functions
-  ...funcs: Funcs
-): IntersectionOfReturns<Funcs> => {
-  const sdkFuncs = funcs.reduce<Partial<IntersectionOfReturns<Funcs>>>(
-    (accum, func) => {
-      const sdkSlice = func(config);
-      return Object.assign(accum, sdkSlice);
-    },
-    {}
-  );
-
-  return sdkFuncs as IntersectionOfReturns<Funcs>;
-};
-
-export const constructSDK = <TxResponse = any>(
-  config: SDKConfig<TxResponse>
-): AllSDKMethods<TxResponse> =>
-  // include all available functions
-  constructPartialSDK(
-    config,
-    constructGetBalances,
-    constructGetTokens,
-    constructGetSpender,
-    constructApproveToken as (
-      options: ConstructProviderFetchInput<TxResponse>
-    ) => ApproveTokenFunctions<TxResponse>, // @TODO try Instantiation Expression when TS 4.7 `as constructApproveToken<TxResponse>`
-    constructBuildTx,
-    constructGetAdapters,
-    constructGetRate
-  );
+export { SDKConfig, constructPartialSDK } from './sdk/partial';
+export { AllSDKMethods, constructFullSDK } from './sdk/full';
+export { SDKFetchMethods, constructSimpleSDK } from './sdk/simple';
 
 export { ParaSwap } from './legacy';

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,6 @@ export {
   constructGetRate,
   isFetcherError,
 };
-// @TODO missing fro parity with older SDK:
-// getRate, getRateByRoute
 
 export type {
   ApproveTokenFunctions,
@@ -64,12 +62,13 @@ export type {
   PriceString,
 };
 
-export type SDKConfig = ConstructProviderFetchInput & ConstructFetchInput;
+export type SDKConfig<TxResponse = any> =
+  ConstructProviderFetchInput<TxResponse> & ConstructFetchInput;
 
-export type AllSDKMethods = GetBalancesFunctions &
+export type AllSDKMethods<TxResponse> = GetBalancesFunctions &
   GetTokensFunctions &
   GetSpenderFunctions &
-  ApproveTokenFunctions &
+  ApproveTokenFunctions<TxResponse> &
   BuildTxFunctions &
   AdaptersFunctions &
   GetRateFunctions;
@@ -102,14 +101,18 @@ export const constructPartialSDK = <
   return sdkFuncs as IntersectionOfReturns<Funcs>;
 };
 
-export const constructSDK = (config: SDKConfig): AllSDKMethods =>
+export const constructSDK = <TxResponse = any>(
+  config: SDKConfig<TxResponse>
+): AllSDKMethods<TxResponse> =>
   // include all available functions
   constructPartialSDK(
     config,
     constructGetBalances,
     constructGetTokens,
     constructGetSpender,
-    constructApproveToken,
+    constructApproveToken as (
+      options: ConstructProviderFetchInput<TxResponse>
+    ) => ApproveTokenFunctions<TxResponse>, // @TODO try Instantiation Expression when TS 4.7 `as constructApproveToken<TxResponse>`
     constructBuildTx,
     constructGetAdapters,
     constructGetRate

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -1,12 +1,7 @@
 import type { AxiosStatic } from 'axios';
 import type Web3 from 'web3';
 import type { SendOptions } from 'web3-eth-contract';
-import type { Contract as EthersContract } from '@ethersproject/contracts';
-import type { Signer } from '@ethersproject/abstract-signer';
-
-import type { BaseProvider } from '@ethersproject/providers';
 import type { ContractTransaction } from '@ethersproject/contracts';
-
 import type { Address, OptimalRate } from 'paraswap-core';
 
 import { API_URL, SwapSide } from '../constants';
@@ -19,7 +14,7 @@ import {
   constructGetTokens,
   constructPartialSDK,
   constructGetRate,
-  constructSDK,
+  constructFullSDK,
   PriceString,
 } from '..';
 import { assert } from 'ts-essentials';
@@ -29,14 +24,14 @@ import {
   constructEthersContractCaller,
   constructWeb3ContractCaller,
   isFetcherError,
+  Web3UnpromiEvent,
+  EthersProviderDeps,
 } from '../helpers';
 
-import type { RateOptions } from '../rates';
-import type { BuildOptions, TransactionParams } from '../transaction';
-import type { AddressOrSymbol, Token } from '../token';
-import type { Allowance } from '../balance';
-import type { FetcherFunction } from '../types';
-import type { UnpromiEvent } from '../helpers/web3';
+import type { RateOptions } from '../methods/rates';
+import type { BuildOptions, TransactionParams } from '../methods/transaction';
+import type { AddressOrSymbol, Token, FetcherFunction } from '../types';
+import type { Allowance } from '../methods/balance';
 
 export type APIError = {
   message: string;
@@ -45,12 +40,7 @@ export type APIError = {
 };
 type Fetch = typeof fetch;
 
-interface EthersProviderDeps {
-  providerOrSigner: BaseProvider | Signer;
-  Contract: typeof EthersContract;
-}
-
-type TxResponse = UnpromiEvent | ContractTransaction;
+type TxResponse = Web3UnpromiEvent | ContractTransaction;
 
 /** @deprecated */
 export class ParaSwap {
@@ -96,7 +86,7 @@ export class ParaSwap {
       : null;
 
     if (contractCaller) {
-      this.sdk = constructSDK<TxResponse>({
+      this.sdk = constructFullSDK<TxResponse>({
         fetcher,
         contractCaller,
         apiURL,
@@ -138,7 +128,7 @@ export class ParaSwap {
     const contractCaller = constructWeb3ContractCaller(web3Provider, account);
     const { apiURL, network, fetcher } = this;
 
-    this.sdk = constructSDK({
+    this.sdk = constructFullSDK({
       fetcher,
       contractCaller,
       apiURL,
@@ -156,7 +146,7 @@ export class ParaSwap {
     const contractCaller = constructEthersContractCaller(ethersDeps, account);
     const { apiURL, network, fetcher } = this;
 
-    this.sdk = constructSDK({
+    this.sdk = constructFullSDK({
       fetcher,
       contractCaller,
       apiURL,

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -36,7 +36,7 @@ import type { BuildOptions, TransactionParams } from '../transaction';
 import type { AddressOrSymbol, Token } from '../token';
 import type { Allowance } from '../balance';
 import type { FetcherFunction } from '../types';
-import { UnpromiEvent } from '../helpers/web3';
+import type { UnpromiEvent } from '../helpers/web3';
 
 export type APIError = {
   message: string;

--- a/src/methods/adapters.ts
+++ b/src/methods/adapters.ts
@@ -1,6 +1,6 @@
-import { ConstructFetchInput } from './types';
-import { constructSearchString } from './helpers/misc';
-import { API_URL } from './constants';
+import { ConstructFetchInput } from '../types';
+import { constructSearchString } from '../helpers/misc';
+import { API_URL } from '../constants';
 
 type Adapter = {
   adapter: string;
@@ -20,7 +20,7 @@ export type AllAdaptersOptions =
   | OptionsList
   | OptionsListNamesOnly;
 
-interface GetAdapternsFunc {
+interface GetAdaptersFunc {
   (options: OptionsObject, signal?: AbortSignal): Promise<AdaptersAsObject>;
   (options: OptionsList, signal?: AbortSignal): Promise<AdaptersAsList>;
   (
@@ -32,15 +32,15 @@ interface GetAdapternsFunc {
   >;
 }
 
-export type AdaptersFunctions = {
-  getAdapters: GetAdapternsFunc;
+export type GetAdaptersFunctions = {
+  getAdapters: GetAdaptersFunc;
 };
 
 export const constructGetAdapters = ({
   apiURL = API_URL,
   network,
   fetcher,
-}: ConstructFetchInput): AdaptersFunctions => {
+}: ConstructFetchInput): GetAdaptersFunctions => {
   async function getAdapters(
     options: OptionsObject,
     signal?: AbortSignal

--- a/src/methods/approve.ts
+++ b/src/methods/approve.ts
@@ -1,6 +1,10 @@
 import { constructGetSpender } from './spender';
-import type { Address, PriceString } from './token';
-import type { ConstructProviderFetchInput, TxSendOverrides } from './types';
+import type {
+  ConstructProviderFetchInput,
+  TxSendOverrides,
+  Address,
+  PriceString,
+} from '../types';
 
 type ApproveToken<T> = (
   amount: PriceString,
@@ -41,10 +45,10 @@ type ExtractAbiMethodNames<T extends readonly { name: string }[]> =
 
 type AvailableMethods = ExtractAbiMethodNames<typeof MinERC20Abi>;
 
-// @TODO make this generic to return whatever `contractCaller` returns
+// returns whatever `contractCaller` returns
 // to allow for better versatility
 export const constructApproveToken = <T>(
-  options: ConstructProviderFetchInput<T>
+  options: ConstructProviderFetchInput<T, 'transactCall'>
 ): ApproveTokenFunctions<T> => {
   const { getSpender } = constructGetSpender(options);
   // cached for the same instance of `approveToken = constructApproveToken()`

--- a/src/methods/balance.ts
+++ b/src/methods/balance.ts
@@ -1,10 +1,15 @@
-import { API_URL } from './constants';
-import { Token, Address, constructToken, AddressOrSymbol } from './token';
+import { API_URL } from '../constants';
+import {
+  Token,
+  Address,
+  constructToken,
+  AddressOrSymbol,
+} from '../helpers/token';
 import {
   ConstructFetchInput,
   TokenApiResponse,
   TokensApiResponse,
-} from './types';
+} from '../types';
 
 type GetBalances = (
   userAddress: Address,
@@ -31,6 +36,12 @@ type GetAllowance = (
   tokenAddress: Address,
   signal?: AbortSignal
 ) => Promise<Allowance | typeof NOT_FOUND_RESPONSE>;
+
+export const isAllowance = (
+  arg: Awaited<ReturnType<GetAllowance>>
+): arg is Allowance => {
+  return 'allowance' in arg;
+};
 
 export type GetBalancesFunctions = {
   getBalance: GetBalance;

--- a/src/methods/rates.ts
+++ b/src/methods/rates.ts
@@ -1,8 +1,13 @@
 import { OptimalRate } from 'paraswap-core';
-import { SwapSide, ContractMethod, API_URL } from './constants';
-import { constructSearchString } from './helpers/misc';
-import { Address, AddressOrSymbol, PriceString } from './token';
-import { ConstructFetchInput, PriceRouteApiResponse } from './types';
+import { SwapSide, ContractMethod, API_URL } from '../constants';
+import { constructSearchString } from '../helpers/misc';
+import {
+  ConstructFetchInput,
+  PriceRouteApiResponse,
+  Address,
+  AddressOrSymbol,
+  PriceString,
+} from '../types';
 
 // TODO: This is legacy and can be removed
 export enum PricingMethod {

--- a/src/methods/spender.ts
+++ b/src/methods/spender.ts
@@ -1,6 +1,5 @@
-import { API_URL } from './constants';
-import { Address } from './token';
-import { ConstructFetchInput } from './types';
+import { API_URL } from '../constants';
+import { ConstructFetchInput, Address } from '../types';
 
 type GetSpender = (signal?: AbortSignal) => Promise<Address>;
 

--- a/src/methods/token.ts
+++ b/src/methods/token.ts
@@ -1,0 +1,30 @@
+import { API_URL } from '../constants';
+import { constructToken } from '../helpers/token';
+import type { ConstructFetchInput, Token, TokensApiResponse } from '../types';
+
+type GetTokens = (signal?: AbortSignal) => Promise<Token[]>;
+
+export type GetTokensFunctions = {
+  getTokens: GetTokens;
+};
+
+export const constructGetTokens = ({
+  apiURL = API_URL,
+  network,
+  fetcher,
+}: ConstructFetchInput): GetTokensFunctions => {
+  const fetchURL = `${apiURL}/tokens/${network}`;
+
+  const getTokens: GetTokens = async (signal) => {
+    const data = await fetcher<TokensApiResponse>({
+      url: fetchURL,
+      method: 'GET',
+      signal,
+    });
+
+    const tokens = data.tokens.map(constructToken);
+    return tokens;
+  };
+
+  return { getTokens };
+};

--- a/src/methods/transaction.ts
+++ b/src/methods/transaction.ts
@@ -1,11 +1,15 @@
 import type { OptimalRate } from 'paraswap-core';
-import type { WithGasPrice, WithMaxFee } from './gas';
-import type { ConstructFetchInput, Address, FetcherPostInput } from './types';
+import type { WithGasPrice, WithMaxFee } from '../gas';
+import type {
+  ConstructFetchInput,
+  Address,
+  FetcherPostInput,
+  PriceString,
+} from '../types';
 
 import { assert } from 'ts-essentials';
-import { API_URL, SwapSide } from './constants';
-import { PriceString } from './token';
-import { constructSearchString } from './helpers/misc';
+import { API_URL, SwapSide } from '../constants';
+import { constructSearchString } from '../helpers/misc';
 
 export interface TransactionParams {
   to: string;

--- a/src/sdk/full.ts
+++ b/src/sdk/full.ts
@@ -1,0 +1,41 @@
+import {
+  constructApproveToken,
+  ApproveTokenFunctions,
+} from '../methods/approve';
+import { constructGetBalances, GetBalancesFunctions } from '../methods/balance';
+import { constructGetSpender, GetSpenderFunctions } from '../methods/spender';
+import {
+  constructGetAdapters,
+  GetAdaptersFunctions,
+} from '../methods/adapters';
+import { constructGetRate, GetRateFunctions } from '../methods/rates';
+import { constructGetTokens, GetTokensFunctions } from '../methods/token';
+import { constructBuildTx, BuildTxFunctions } from '../methods/transaction';
+import { constructPartialSDK, SDKConfig } from './partial';
+import type { ConstructProviderFetchInput } from '../types';
+
+export type AllSDKMethods<TxResponse> = GetBalancesFunctions &
+  GetTokensFunctions &
+  GetSpenderFunctions &
+  ApproveTokenFunctions<TxResponse> &
+  BuildTxFunctions &
+  GetAdaptersFunctions &
+  GetRateFunctions;
+
+/** @description construct SDK with every method, fetching from API and token approval */
+export const constructFullSDK = <TxResponse = any>(
+  config: SDKConfig<TxResponse>
+): AllSDKMethods<TxResponse> =>
+  // include all available functions
+  constructPartialSDK(
+    config,
+    constructGetBalances,
+    constructGetTokens,
+    constructGetSpender,
+    constructApproveToken as (
+      options: ConstructProviderFetchInput<TxResponse, 'transactCall'>
+    ) => ApproveTokenFunctions<TxResponse>, // @TODO try Instantiation Expression when TS 4.7 `as constructApproveToken<TxResponse>`
+    constructBuildTx,
+    constructGetAdapters,
+    constructGetRate
+  );

--- a/src/sdk/partial.ts
+++ b/src/sdk/partial.ts
@@ -1,0 +1,57 @@
+import { ApproveTokenFunctions } from '../methods/approve';
+import {
+  ConstructBaseInput,
+  ConstructFetchInput,
+  ConstructProviderFetchInput,
+} from '../types';
+import { UnionToIntersection } from 'ts-essentials';
+
+export type SDKConfig<TxResponse = any> = ConstructProviderFetchInput<
+  TxResponse,
+  'transactCall'
+> &
+  ConstructFetchInput;
+
+type AnyFunction = (...args: any[]) => any;
+
+type SDKFunction<T extends ConstructBaseInput> = (
+  config: T
+) => Record<string, AnyFunction>;
+
+type IntersectionOfReturns<Funcs extends AnyFunction[]> = UnionToIntersection<
+  ReturnType<Funcs[number]>
+>;
+
+type ApproveTokenFunctionsKeys = keyof ApproveTokenFunctions<any>;
+
+type PartialSDKResult<
+  Config extends ConstructBaseInput,
+  Funcs extends [SDKFunction<Config>, ...SDKFunction<Config>[]]
+> = IntersectionOfReturns<Funcs> extends ApproveTokenFunctions<any> // if there are ApproveTokenFunctions in the intersection
+  ? // which means constructApproveToken was passed in Funcs
+    Omit<IntersectionOfReturns<Funcs>, ApproveTokenFunctionsKeys> &
+      ApproveTokenFunctions<
+        // infer what TxResponse was used in Config
+        Config extends SDKConfig<infer TxResponse> ? TxResponse : unknown
+        // and make the ApproveTokenFunctions<unknow> in the intersection a specific ApproveTokenFunctions<TxResponse>
+      >
+  : IntersectionOfReturns<Funcs>;
+
+/** @description construct composable SDK with methods you choose yourself */
+export const constructPartialSDK = <
+  Config extends ConstructBaseInput,
+  Funcs extends [SDKFunction<Config>, ...SDKFunction<Config>[]]
+>(
+  config: Config, // config is auto-inferred to cover the used functions
+  ...funcs: Funcs
+): PartialSDKResult<Config, Funcs> => {
+  const sdkFuncs = funcs.reduce<Partial<IntersectionOfReturns<Funcs>>>(
+    (accum, func) => {
+      const sdkSlice = func(config);
+      return Object.assign(accum, sdkSlice);
+    },
+    {}
+  );
+
+  return sdkFuncs as PartialSDKResult<Config, Funcs>;
+};

--- a/src/sdk/simple.ts
+++ b/src/sdk/simple.ts
@@ -1,0 +1,138 @@
+import { constructPartialSDK, SDKConfig } from './partial';
+import {
+  GetAdaptersFunctions,
+  constructGetAdapters,
+} from '../methods/adapters';
+import { GetBalancesFunctions, constructGetBalances } from '../methods/balance';
+import { GetRateFunctions, constructGetRate } from '../methods/rates';
+import { GetSpenderFunctions, constructGetSpender } from '../methods/spender';
+import { GetTokensFunctions, constructGetTokens } from '../methods/token';
+import { BuildTxFunctions, constructBuildTx } from '../methods/transaction';
+
+import {
+  constructAxiosFetcher,
+  constructFetchFetcher,
+  constructEthersContractCaller,
+  constructWeb3ContractCaller,
+} from '../helpers';
+
+import type {
+  ConstructBaseInput,
+  ConstructFetchInput,
+  ContractCallerFunctions,
+  TransactionContractCallerFn,
+  TxHash,
+  Address,
+} from '../types';
+
+import type { EthersProviderDeps } from '../helpers';
+import type Web3 from 'web3';
+
+import type AxiosStatic from 'axios';
+import { AllSDKMethods, constructFullSDK } from './full';
+
+export type SDKFetchMethods = GetBalancesFunctions &
+  GetTokensFunctions &
+  GetSpenderFunctions &
+  BuildTxFunctions &
+  GetAdaptersFunctions &
+  GetRateFunctions;
+
+type SimpleOptions = ConstructBaseInput &
+  (
+    | {
+        axios: typeof AxiosStatic;
+      }
+    | { fetch: typeof fetch }
+  );
+
+type ProviderOptions = (EthersProviderDeps | { web3: Web3 }) & {
+  account: Address;
+};
+
+/** @description construct SDK with methods that fetch from API and optionally with token approval methods */
+export function constructSimpleSDK(options: SimpleOptions): SDKFetchMethods;
+export function constructSimpleSDK(
+  options: SimpleOptions,
+  providerOptions: ProviderOptions
+): AllSDKMethods<TxHash>;
+export function constructSimpleSDK(
+  options: SimpleOptions,
+  providerOptions?: ProviderOptions
+): SDKFetchMethods | AllSDKMethods<TxHash> {
+  const fetcher =
+    'axios' in options
+      ? constructAxiosFetcher(options.axios)
+      : constructFetchFetcher(options.fetch);
+
+  if (!providerOptions) {
+    const config: ConstructFetchInput = {
+      apiURL: options.apiURL,
+      network: options.network,
+      fetcher,
+    };
+
+    // include all available functions that don't need `contractCaller`
+    const sdk: SDKFetchMethods = constructPartialSDK(
+      config,
+      constructGetBalances,
+      constructGetTokens,
+      constructGetSpender,
+      constructBuildTx,
+      constructGetAdapters,
+      constructGetRate
+    );
+
+    return sdk;
+  }
+
+  const contractCaller = constructSimpleContractCaller(providerOptions);
+
+  const config: SDKConfig<TxHash> = {
+    apiURL: options.apiURL,
+    network: options.network,
+    fetcher,
+    contractCaller,
+  };
+
+  const sdk: AllSDKMethods<TxHash> = constructFullSDK(config);
+
+  return sdk;
+}
+
+function constructSimpleContractCaller(
+  providerOptions: ProviderOptions
+): ContractCallerFunctions<TxHash> {
+  if ('ethersProviderOrSigner' in providerOptions) {
+    const { staticCall, transactCall: _transactCall } =
+      constructEthersContractCaller(providerOptions, providerOptions.account);
+
+    const transactCall: TransactionContractCallerFn<TxHash> = async (
+      params
+    ) => {
+      const contractTx = await _transactCall(params);
+
+      // as soon as tx is sent
+      // returning tx hash, it's up to the user to wait for tx
+      return contractTx.hash;
+    };
+
+    return { staticCall, transactCall };
+  }
+
+  const { staticCall, transactCall: _transactCall } =
+    constructWeb3ContractCaller(providerOptions.web3, providerOptions.account);
+
+  const transactCall: TransactionContractCallerFn<TxHash> = async (params) => {
+    const unpromiEvent = await _transactCall(params);
+
+    // as soon as tx is sent
+    // returning tx hash, it's up to the user to wait for tx
+    return new Promise<TxHash>((resolve, reject) => {
+      unpromiEvent.once('transactionHash', resolve);
+      unpromiEvent.once('error', reject);
+    });
+  };
+
+  return { staticCall, transactCall };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,19 +48,16 @@ interface ContractCallInput<T extends string> {
   address: Address;
   abi: ReadonlyArray<JsonFragment>;
   contractMethod: T;
-  static: boolean;
   args: any[];
 }
 
 interface ContractCallStaticInput<T extends string>
   extends ContractCallInput<T> {
-  static: true;
   overrides: StaticCallOverrides;
 }
 
 interface ContractCallTransactionInput<T extends string>
   extends ContractCallInput<T> {
-  static: false;
   overrides: TxSendOverrides;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,14 @@
 import type { JsonFragment } from '@ethersproject/abi';
 import { OptimalRate } from 'paraswap-core';
-import { Address, Token, TxHash } from './token';
+import {
+  Address,
+  AddressOrSymbol,
+  PriceString,
+  Token,
+  TxHash,
+} from './helpers/token';
 
-export type { Address, Token, TxHash };
+export type { Address, AddressOrSymbol, PriceString, Token, TxHash };
 
 export interface ConstructBaseInput {
   apiURL?: string;
@@ -61,10 +67,7 @@ interface ContractCallTransactionInput<T extends string>
   overrides: TxSendOverrides;
 }
 
-export type ContractCallerFunction = <T, M extends string = string>(
-  params: ContractCallTransactionInput<M> | ContractCallStaticInput<M>
-) => Promise<T>;
-
+// may have to type result T differently if we ever use staticCalls in SDK
 export type StaticContractCallerFn = <T, M extends string = string>(
   params: ContractCallStaticInput<M>
 ) => Promise<T>;
@@ -77,8 +80,11 @@ export interface ContractCallerFunctions<T> {
   transactCall: TransactionContractCallerFn<T>;
 }
 
-export interface ConstructProviderFetchInput<T> extends ConstructFetchInput {
-  contractCaller: ContractCallerFunctions<T>;
+export interface ConstructProviderFetchInput<
+  T,
+  D extends keyof ContractCallerFunctions<T> = keyof ContractCallerFunctions<T>
+> extends ConstructFetchInput {
+  contractCaller: Pick<ContractCallerFunctions<T>, D>;
 }
 
 export type TokenFromApi = Pick<

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,8 +68,20 @@ export type ContractCallerFunction = <T, M extends string = string>(
   params: ContractCallTransactionInput<M> | ContractCallStaticInput<M>
 ) => Promise<T>;
 
-export interface ConstructProviderFetchInput extends ConstructFetchInput {
-  contractCaller: ContractCallerFunction;
+export type StaticContractCallerFn = <T, M extends string = string>(
+  params: ContractCallStaticInput<M>
+) => Promise<T>;
+export type TransactionContractCallerFn<T> = <M extends string = string>(
+  params: ContractCallTransactionInput<M>
+) => Promise<T>;
+
+export interface ContractCallerFunctions<T> {
+  staticCall: StaticContractCallerFn;
+  transactCall: TransactionContractCallerFn<T>;
+}
+
+export interface ConstructProviderFetchInput<T> extends ConstructFetchInput {
+  contractCaller: ContractCallerFunctions<T>;
 }
 
 export type TokenFromApi = Pick<

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -179,8 +179,8 @@ describe('ParaSwap SDK', () => {
     const adapters = adaptersOrError as Adapters;
 
     expect(adapters.paraswappool[0].adapter).toBeDefined();
-    expect(adapters.uniswap[0].adapter).toBeDefined();
-    expect(adapters.uniswap[0].index).toBeDefined();
+    expect(adapters.uniswapv2[0].adapter).toBeDefined();
+    expect(adapters.uniswapv2[0].index).toBeDefined();
     expect(adapters.kyber[0].adapter).toBeDefined();
     expect(adapters.kyber[0].index).toBeDefined();
   });

--- a/tests/legacy.test.ts
+++ b/tests/legacy.test.ts
@@ -1,0 +1,322 @@
+import * as dotenv from 'dotenv';
+import Web3 from 'web3';
+import { ethers } from 'ethers';
+// import axios from 'axios';
+import fetch from 'isomorphic-unfetch';
+import { ParaSwap, Token, Allowance, TransactionParams } from '../src';
+import BigNumber from 'bignumber.js';
+import { SwapSide } from '../src';
+import { OptimalRate, Adapters } from 'paraswap-core';
+import { APIError } from '../src/legacy';
+import erc20abi from './abi/ERC20.json';
+
+import ganache from 'ganache';
+
+dotenv.config();
+
+jest.setTimeout(30 * 1000);
+
+declare let process: any;
+
+const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+const BAT = '0x0d8775f648430679a709e98d2b0cb6250d2887ef';
+const MANA = '0x0f5d2fb29fb7d3cfee444a200298f468908cc942';
+
+const TESTING_ENV = true;
+const PROVIDER_URL = process.env.PROVIDER_URL;
+const network = 1;
+const srcToken = ETH;
+const destToken = DAI;
+const srcAmount = (1 * 1e18).toString(); //The source amount multiplied by its decimals
+
+const referrer = 'sdk-test';
+
+const wallet = ethers.Wallet.createRandom();
+
+const ganacheProvider = ganache.provider({
+  wallet: {
+    accounts: [{ balance: 8e18, secretKey: wallet.privateKey }],
+  },
+  fork: {
+    url: PROVIDER_URL,
+  },
+  chain: {
+    chainId: 1,
+  },
+  quiet: true,
+});
+
+const provider = new Web3(ganacheProvider as any);
+
+const ethersProvider = new ethers.providers.Web3Provider(
+  ganacheProvider as any
+);
+
+const signer = wallet.connect(ethersProvider);
+const senderAddress = signer.address;
+
+describe('ParaSwap SDK', () => {
+  let paraSwap: ParaSwap;
+
+  beforeAll(async () => {
+    paraSwap = new ParaSwap(
+      network,
+      undefined,
+      undefined,
+      undefined,
+      senderAddress,
+      undefined, // `axios` will take precedence if given
+      fetch
+    ).setWeb3Provider(provider);
+  });
+
+  test('Get_Balance', async () => {
+    const balance = await paraSwap.getBalance(senderAddress, ETH);
+    expect(balance).toBeDefined();
+  });
+
+  test('Get_Markets', async () => {
+    const markets = await paraSwap.getMarketNames();
+    expect((markets as string[]).length).toBeGreaterThan(15);
+  });
+
+  test('Get_Tokens', async () => {
+    const tokensOrError = await paraSwap.getTokens();
+
+    const tokens = tokensOrError as Token[];
+
+    expect(Array.isArray(tokens)).toBe(true);
+    expect(tokens.length).toBeGreaterThan(0);
+    expect(tokens[0]).toEqual(
+      expect.objectContaining({
+        symbol: expect.any(String),
+        address: expect.any(String),
+        decimals: expect.any(Number),
+      })
+    );
+  });
+
+  test('Get_Rates', async () => {
+    const ratesOrError = await paraSwap.getRate(
+      'ETH',
+      'DAI',
+      srcAmount,
+      senderAddress,
+      SwapSide.SELL,
+      { includeDEXS: 'UniswapV2', otherExchangePrices: true }
+    );
+    const priceRoute = ratesOrError as OptimalRate;
+
+    const { destAmount, bestRoute, others } = priceRoute;
+
+    expect(typeof destAmount).toBe('string');
+
+    expect(Array.isArray(bestRoute)).toBe(true);
+
+    const swapExchange = bestRoute[0]?.swaps[0]?.swapExchanges[0];
+
+    expect(swapExchange).toBeDefined();
+
+    expect(typeof swapExchange.destAmount).toBe('string');
+    expect(new BigNumber(swapExchange.destAmount).isNaN()).toBe(false);
+
+    expect(typeof swapExchange.exchange).toBe('string');
+
+    expect(typeof bestRoute[0].percent).toBe('number');
+    expect(new BigNumber(bestRoute[0].percent).isNaN()).toBe(false);
+
+    expect(typeof swapExchange.srcAmount).toBe('string');
+    expect(new BigNumber(swapExchange.srcAmount).isNaN()).toBe(false);
+
+    expect(Array.isArray(others)).toBe(true);
+
+    expect(typeof others![0].exchange).toBe('string');
+
+    expect(typeof others![0].unit).toBe('string');
+    expect(new BigNumber(others![0].unit as string).isNaN()).toBe(false);
+  });
+
+  test('Get_Spender', async () => {
+    const spender = await paraSwap.getTokenTransferProxy();
+    expect(provider.utils.isAddress(spender as string));
+  });
+
+  test('Get_Allowance', async () => {
+    const allowance = await paraSwap.getAllowance(senderAddress, DAI);
+
+    if (!allowance || (allowance as APIError).message) {
+      return;
+    }
+
+    expect(new BigNumber((allowance as Allowance).allowance).isNaN()).toBe(
+      false
+    );
+  });
+
+  test('Get_Allowances', async () => {
+    const allowancesOrError = await paraSwap.getAllowances(senderAddress, [
+      DAI,
+      BAT,
+      MANA,
+    ]);
+
+    const allowances = allowancesOrError as Allowance[];
+
+    await Promise.all(
+      allowances.map((allowance) =>
+        expect(new BigNumber(allowance.allowance).isNaN()).toBe(false)
+      )
+    );
+  });
+
+  test('Get_Adapters', async () => {
+    const adaptersOrError = await paraSwap.getAdapters();
+
+    const adapters = adaptersOrError as Adapters;
+
+    expect(adapters.paraswappool[0].adapter).toBeDefined();
+    expect(adapters.uniswapv2[0].adapter).toBeDefined();
+    expect(adapters.uniswapv2[0].index).toBeDefined();
+    expect(adapters.kyberdmm[0].adapter).toBeDefined();
+    expect(adapters.kyberdmm[0].index).toBeDefined();
+  });
+
+  test('Build_Tx', async () => {
+    const destToken = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const ratesOrError = await paraSwap.getRate(
+      srcToken,
+      destToken,
+      srcAmount,
+      senderAddress,
+      SwapSide.SELL,
+      { includeDEXS: 'UniswapV2' }
+    );
+
+    expect((ratesOrError as APIError)?.data?.error).toBeUndefined();
+
+    const priceRoute = ratesOrError as OptimalRate;
+
+    const destAmount = new BigNumber(priceRoute.destAmount)
+      .times(0.99)
+      .toFixed(0);
+
+    const txOrError = await paraSwap.buildTx(
+      srcToken,
+      destToken,
+      srcAmount,
+      destAmount,
+      priceRoute,
+      senderAddress,
+      referrer,
+      undefined,
+      undefined,
+      undefined,
+      { ignoreChecks: true }
+    );
+
+    expect(txOrError.data.error).toBeUndefined();
+    expect(typeof txOrError).toBe('object');
+  });
+  if (TESTING_ENV) {
+    test('Build_and_Send_Tx', async () => {
+      const ratesOrError = await paraSwap.getRate(
+        srcToken,
+        destToken,
+        srcAmount,
+        senderAddress,
+        SwapSide.SELL,
+        { includeDEXS: 'Uniswap,UniswapV2,Balancer,Oasis' }
+      );
+      const priceRoute = ratesOrError as OptimalRate;
+      const destAmount = new BigNumber(priceRoute.destAmount)
+        .times(0.99)
+        .toFixed(0);
+
+      const txOrError = await paraSwap.buildTx(
+        srcToken,
+        destToken,
+        srcAmount,
+        destAmount,
+        priceRoute,
+        signer.address,
+        referrer,
+        undefined,
+        undefined,
+        undefined,
+        { ignoreChecks: true }
+      );
+      const _tx = txOrError as TransactionParams;
+      const transaction = {
+        ..._tx,
+        gasPrice: '0x' + new BigNumber(_tx.gasPrice).toString(16),
+        gasLimit: '0x' + new BigNumber(5000000).toString(16),
+        value: '0x' + new BigNumber(_tx.value).toString(16),
+      };
+      const toContract = new ethers.Contract(
+        destToken,
+        erc20abi,
+        ethersProvider
+      );
+      const beforeFromBalance = await ethersProvider.getBalance(signer.address);
+      const beforeToBalance = await toContract.balanceOf(signer.address);
+
+      const txr = await signer.sendTransaction(transaction);
+      await txr.wait(1);
+      const afterFromBalance = await ethersProvider.getBalance(signer.address);
+      const afterToBalance = await toContract.balanceOf(signer.address);
+      expect(beforeFromBalance.gt(afterFromBalance)).toBeTruthy();
+      expect(beforeToBalance.lt(afterToBalance)).toBeTruthy();
+    });
+    test('Build_and_Send_Tx_BUY', async () => {
+      const destAmount = srcAmount;
+      const ratesOrError = await paraSwap.getRate(
+        srcToken,
+        destToken,
+        destAmount,
+        senderAddress,
+        SwapSide.BUY,
+        { includeDEXS: 'Uniswap,UniswapV2,Balancer,Oasis' }
+      );
+      const priceRoute = ratesOrError as OptimalRate;
+      const _srcAmount = new BigNumber(priceRoute.srcAmount)
+        .times(1.1)
+        .toFixed(0);
+
+      const txOrError = await paraSwap.buildTx(
+        srcToken,
+        destToken,
+        _srcAmount,
+        destAmount,
+        priceRoute,
+        signer.address,
+        referrer,
+        undefined,
+        undefined,
+        undefined,
+        { ignoreChecks: true }
+      );
+      const _tx = txOrError as TransactionParams;
+      const transaction = {
+        ..._tx,
+        gasPrice: '0x' + new BigNumber(_tx.gasPrice).toString(16),
+        gasLimit: '0x' + new BigNumber(5000000).toString(16),
+        value: '0x' + new BigNumber(_tx.value).toString(16),
+      };
+      const toContract = new ethers.Contract(
+        destToken,
+        erc20abi,
+        ethersProvider
+      );
+      const beforeFromBalance = await ethersProvider.getBalance(signer.address);
+      const beforeToBalance = await toContract.balanceOf(signer.address);
+
+      const txr = await signer.sendTransaction(transaction);
+      await txr.wait(1);
+      const afterFromBalance = await ethersProvider.getBalance(signer.address);
+      const afterToBalance = await toContract.balanceOf(signer.address);
+      expect(beforeFromBalance.gt(afterFromBalance)).toBeTruthy();
+      expect(beforeToBalance.lt(afterToBalance)).toBeTruthy();
+    });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
-  "include": ["src", "types"],
+  "include": ["src", "types", "tests"],
   "compilerOptions": {
     "module": "esnext",
     "resolveJsonModule": true,


### PR DESCRIPTION
Makes `contractCaller` more generic, so `paraswap.approveToken() returns what contractCaller.tranasctCall() returns` with some caveats when dealing with **Web3**

It got complicated with PromiEvent, so need tests first before merging