### PR TITLE
Sdk refactoring simple helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ const signer = ethers.Wallet.fromMnmemonic('__your_mnemonic__') // or any other 
 const account = '__signer_address__'
 
 const contractCaller = constructEthersContractCaller({
-  providerOrSigner: signer,
-  Contract: ethers.Contract,
+  ethersProviderOrSigner: signer,
+  EthersContract: ethers.Contract,
 }, account); // alternatively constructWeb3ContractCaller
 const fetcher = constructAxiosFetcher(axios); // alternatively constructFetchFetcher
 
@@ -140,7 +140,16 @@ const paraswap = constructSDK({
 ### To approve ParaSwap contracts to swap an ERC20 token
 
 ```typescript
-const txHash = await paraSwap.approveToken(amount, tokenAddress);
+// if created with constructEthersContractCaller
+const contractTx: ContractTransaction = await paraSwap.approveToken(amount, tokenAddress);
+const txReceipt = await contractTx.wait();
+
+// if created with constructWeb3ContractCaller
+const unpromiEvent: Web3UnpromiEvent = await paraSwap.approveToken(amount, tokenAddress);
+const txReceipt = await new Promise<Web3TransactionReceipt>((resolve, reject) => {
+  unpromiEvent.once('receipt', resolve);
+  unpromiEvent.once('error', reject);
+})
 ```
 
 ### To get the rate of a token pair

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are multiple ways to use ParaSwap SDK, ranging from simple construct-and-u
 
 ### Simple SDK
 
-Can be created by providing `network` and either `axios` or `window.fetch` (or alternative `fetch` implemetation). Resulting SDK will be able to use all methoda that query the API.
+Can be created by providing `network` and either `axios` or `window.fetch` (or alternative `fetch` implementation). Resulting SDK will be able to use all methods that query the API.
 
 ```ts
   import { constructSimpleSDK } from '@paraswap/sdk'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ yarn add @paraswap/sdk
 
 ## Using ParaSwap SDK
 
-There are multiple ways to use ParaSwap SDK, ranging from simple construct-and-use approach to a fully composable _bring what you need_ way that allows for advanced tree-shaking a minimizes bundle size.
+There are multiple ways to use ParaSwap SDK, ranging from simple construct-and-use approach to a fully composable _bring what you need_ way that allows for advanced tree-shaking and minimizes bundle size.
 
 ### Simple SDK
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ There are multiple ways to use ParaSwap SDK, ranging from a simple construct-and
 Can be created by providing `network` and either `axios` or `window.fetch` (or alternative `fetch` implementation). The resulting SDK will be able to use all methods that query the API.
 
 ```ts
-  import { constructSimpleSDK } from '@paraswap/sdk'
-  import axios from 'axios'
+  import { constructSimpleSDK } from '@paraswap/sdk';
+  import axios from 'axios';
 
   // construct minimal SDK with fetcher only
-  const paraSwapMin = constructSimpleSDK({network: 1, axios})
+  const paraSwapMin = constructSimpleSDK({network: 1, axios});
   // or
-  const paraSwapMin = constructSimpleSDK({network: 1, fetch: window.fetch})
+  const paraSwapMin = constructSimpleSDK({network: 1, fetch: window.fetch});
 
   const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
   const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
 
   async function swapExample() {
     const signer: JsonRpcSigner = ...
-    const senderAddress = signer.address
+    const senderAddress = signer.address;
 
     const priceRoute = await paraSwapMin.getRate({
       srcToken: ETH,
@@ -78,13 +78,13 @@ Can be created by providing `network` and either `axios` or `window.fetch` (or a
 
 
   async function approveTokenYourselfExample() {
-    const TransferProxy = await paraSwapMin.getSpender()
+    const TransferProxy = await paraSwapMin.getSpender();
 
-    const DAI_CONTRACT = new ethers.Contract(DAI, ERC20_ABI, ethersSignerOrProvider)
+    const DAI_CONTRACT = new ethers.Contract(DAI, ERC20_ABI, ethersSignerOrProvider);
 
-    const tx = await DAI_CONTRACT.approve(TransferProxy, amountInWei)
+    const tx = await DAI_CONTRACT.approve(TransferProxy, amountInWei);
 
-    const txReceipt = await tx.wait(1)
+    const txReceipt = await tx.wait(1);
   }
 
 ```
@@ -106,13 +106,13 @@ If optional `providerOptions` is provided as the second parameter, then the resu
     account: senderAddress,
   };
 
-  const paraSwap = constructSimpleSDK({network: 1, axios}, providerOptionsEther)
+  const paraSwap = constructSimpleSDK({network: 1, axios}, providerOptionsEther);
 
   async function approveTokenExample() {
-    const txHash = await paraSwap.approveToken(amountInWei, DAI)
+    const txHash = await paraSwap.approveToken(amountInWei, DAI);
 
     // await tx somehow
-    await provider.waitForTransaction(txHash)
+    await provider.waitForTransaction(txHash);
   }
 ```
 
@@ -124,8 +124,8 @@ import { constructSDK, constructAxiosFetcher, constructEthersContractCaller } fr
 ### Construct the ParaSwap object
 
 ```typescript
-const signer = ethers.Wallet.fromMnmemonic('__your_mnemonic__') // or any other signer/provider 
-const account = '__signer_address__'
+const signer = ethers.Wallet.fromMnmemonic('__your_mnemonic__'); // or any other signer/provider 
+const account = '__signer_address__';
 
 const contractCaller = constructEthersContractCaller({
   ethersProviderOrSigner: signer,
@@ -161,8 +161,8 @@ const txReceipt = await new Promise<Web3TransactionReceipt>((resolve, reject) =>
 const srcToken = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'; // ETH
 const destToken = '0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5'; // PSP
 const srcAmount = '1000000000000000000'; //The source amount multiplied by its decimals: 10 ** 18 here
-const srcDecimals = 18
-const destDecimals = 18
+const srcDecimals = 18;
+const destDecimals = 18;
 
 const priceRoute = await paraSwap.getRate(
   {
@@ -181,15 +181,15 @@ Where priceRoute contains the rate and the distribution among exchanges, checkou
 
 ```typescript
 const srcToken = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-const srcDecimals = 18
+const srcDecimals = 18;
 const srcAmount = '1000000000000000000'; // The source amount multiplied by its decimals
 const destToken = '0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5';
-const destDecimals = 18
-const destAmount = priceRoute.destAmount // price route being output of paraSwap.getRate()
+const destDecimals = 18;
+const destAmount = priceRoute.destAmount; // price route being output of paraSwap.getRate()
 const senderAddress = '__sender_address__'; // mandatory
 const receiver = '__receiver_address__'; // optional: for swap and transfer
-const partnerAddress = '__fee_receiver_address__' // optional: for permission-less monetization
-const partnerFeeBps = 50 // optional: fee in base point, for permission-less monetization
+const partnerAddress = '__fee_receiver_address__'; // optional: for permission-less monetization
+const partnerFeeBps = 50; // optional: fee in base point, for permission-less monetization
 
 
 const txParams = await paraSwap.buildTx(
@@ -223,14 +223,14 @@ e.g. for only getting rates and allowances:
 ```typescript
 import { constructPartialSDK, constructFetchFetcher, constructGetRate, constructGetBalances } from '@paraswap/sdk';
 
-const fetcher = constructFetchFetcher(window.fetch)
+const fetcher = constructFetchFetcher(window.fetch);
 
 const minParaSwap = constructPartialSDK({
   network: 1,
   fetcher,
-}, constructGetRate, constructGetBalances)
+}, constructGetRate, constructGetBalances);
 
-const priceRoute = await minParaSwap.getRate(params)
+const priceRoute = await minParaSwap.getRate(params);
 const allowance = await minParaSwap.getAllowance(userAddress, tokenAddress);
 ```
 
@@ -238,12 +238,12 @@ const allowance = await minParaSwap.getAllowance(userAddress, tokenAddress);
 The `ParaSwap` class is exposed for backwards compatibility with previous versions of the SDK.
 
 ```typescript
-import { ParaSwap } from '@paraswap/sdk'
-import axios from 'axios'
-import Web3 from 'web3'
+import { ParaSwap } from '@paraswap/sdk';
+import axios from 'axios';
+import Web3 from 'web3';
 
-const web3Provider = new Web3(window.ethereum)
-const account = '__user_address__'
+const web3Provider = new Web3(window.ethereum);
+const account = '__user_address__';
 
 const paraswap = new ParaSwap(
   1, 
@@ -252,14 +252,14 @@ const paraswap = new ParaSwap(
   undefined, 
   account, 
   axios
-)
+);
 
 ```
 
 By analogy to ```constructPartialSDK```, you can leverage a lightweight version of the sdk for fetching only.
 
 ```typescript
-import { ParaSwap } from '@paraswap/sdk'
+import { ParaSwap } from '@paraswap/sdk';
 
 const paraswap = new ParaSwap(
   1, 
@@ -269,7 +269,7 @@ const paraswap = new ParaSwap(
   undefined, 
   undefined,
   window.fetch
-)
+);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ yarn add @paraswap/sdk
 
 ## Using ParaSwap SDK
 
-There are multiple ways to use ParaSwap SDK, ranging from simple construct-and-use approach to a fully composable _bring what you need_ way that allows for advanced tree-shaking and minimizes bundle size.
+There are multiple ways to use ParaSwap SDK, ranging from a simple construct-and-use approach to a fully composable _bring what you need_ approach which allows for advanced tree-shaking and minimizes bundle size.
 
 ### Simple SDK
 
-Can be created by providing `network` and either `axios` or `window.fetch` (or alternative `fetch` implementation). Resulting SDK will be able to use all methods that query the API.
+Can be created by providing `network` and either `axios` or `window.fetch` (or alternative `fetch` implementation). The resulting SDK will be able to use all methods that query the API.
 
 ```ts
   import { constructSimpleSDK } from '@paraswap/sdk'
@@ -37,6 +37,9 @@ Can be created by providing `network` and either `axios` or `window.fetch` (or a
   const paraSwapMin = constructSimpleSDK({network: 1, axios})
   // or
   const paraSwapMin = constructSimpleSDK({network: 1, fetch: window.fetch})
+
+  const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+  const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
 
   async function swapExample() {
     const signer: JsonRpcSigner = ...

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Can be created by providing `network` and either `axios` or `window.fetch` (or a
 
 ```
 
-If additionally provided `providerOptions` as the second parameter, the resulting SDK will also be able to approve Tokens for swap.
+If optional `providerOptions` is provided as the second parameter, then the resulting SDK will also be able to approve Tokens for swap.
 
 ```ts
   // 

--- a/src/examples/partial.ts
+++ b/src/examples/partial.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import axios from 'axios';
 import { ethers } from 'ethers';
-import { constructPartialSDK, constructSDK } from '..';
-import { constructGetAdapters } from '../adapters';
-import { constructApproveToken } from '../approve';
 import {
+  constructPartialSDK,
+  constructGetAdapters,
+  constructApproveToken,
   constructEthersContractCaller,
   constructAxiosFetcher,
-} from '../helpers';
+} from '..';
 
 const fetcher = constructAxiosFetcher(axios);
 

--- a/src/examples/partial.ts
+++ b/src/examples/partial.ts
@@ -17,7 +17,7 @@ const contractCaller = constructEthersContractCaller({
   EthersContract: ethers.Contract,
 });
 
-//  type = AdaptersFunctions & ApproveTokenFunctions<ethers.ContractTransaction>
+// type AdaptersFunctions & ApproveTokenFunctions<ethers.ContractTransaction>
 const part1 = constructPartialSDK(
   {
     network: 1,
@@ -28,7 +28,7 @@ const part1 = constructPartialSDK(
   constructApproveToken
 );
 
-// type = AdaptersAsObject
+// type Promise<AdaptersAsObject>
 const res1 = part1.getAdapters({ type: 'object' });
-// type = ethers.ContractTransaction
+// type Promise<ethers.ContractTransaction>
 const res2 = part1.approveToken('123', '0x...');

--- a/src/examples/partial.ts
+++ b/src/examples/partial.ts
@@ -13,8 +13,8 @@ const fetcher = constructAxiosFetcher(axios);
 
 const provider = ethers.getDefaultProvider(1);
 const contractCaller = constructEthersContractCaller({
-  providerOrSigner: provider,
-  Contract: ethers.Contract,
+  ethersProviderOrSigner: provider,
+  EthersContract: ethers.Contract,
 });
 
 //  type = AdaptersFunctions & ApproveTokenFunctions<ethers.ContractTransaction>

--- a/src/examples/sdk.ts
+++ b/src/examples/sdk.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import axios from 'axios';
 import { ethers } from 'ethers';
-import { constructPartialSDK, constructSDK } from '..';
-import { constructGetAdapters } from '../adapters';
 import {
+  constructPartialSDK,
+  constructSDK,
+  constructGetAdapters,
   constructEthersContractCaller,
   constructAxiosFetcher,
-} from '../helpers';
+} from '..';
 
 const fetcher = constructAxiosFetcher(axios);
 

--- a/src/examples/sdk.ts
+++ b/src/examples/sdk.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { ethers } from 'ethers';
 import {
   constructPartialSDK,
-  constructSDK,
+  constructFullSDK,
   constructGetAdapters,
   constructEthersContractCaller,
   constructAxiosFetcher,
@@ -13,11 +13,11 @@ const fetcher = constructAxiosFetcher(axios);
 
 const provider = ethers.getDefaultProvider(1);
 const contractCaller = constructEthersContractCaller({
-  providerOrSigner: provider,
-  Contract: ethers.Contract,
+  ethersProviderOrSigner: provider,
+  EthersContract: ethers.Contract,
 });
 
-const paraswap = constructSDK({
+const paraswap = constructFullSDK({
   apiURL: '',
   network: 1,
   fetcher,

--- a/src/examples/sdk.ts
+++ b/src/examples/sdk.ts
@@ -26,9 +26,9 @@ const paraswap = constructFullSDK({
 
 const res = paraswap.getAdapters({ type: 'list', namesOnly: false });
 
-// type ContractTransaction
+// type Promise<ContractTransaction>
 const txResponse = paraswap.approveToken('1', '0x...');
-// type ContractTransaction[]
+// type Promise<ContractTransaction[]>
 const txResponses = paraswap.approveTokenBulk('1', ['0x...']);
 
 const part1 = constructPartialSDK(

--- a/src/examples/simple.ts
+++ b/src/examples/simple.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import axios from 'axios';
+import { ethers } from 'ethers';
+import { constructSimpleSDK, SwapSide } from '..';
+
+// only methods that fetch from API
+const simpleFetchOnlySDK = constructSimpleSDK({ network: 1, axios });
+
+const account = '0x...';
+
+// type Promise<OptimalRate>
+const rateRes = simpleFetchOnlySDK.getRate({
+  srcToken: '0x...',
+  destToken: '0x...',
+  amount: '1000000000000',
+  userAddress: account,
+  side: SwapSide.SELL,
+});
+
+const provider = ethers.getDefaultProvider(1);
+const providerOptions = {
+  ethersProviderOrSigner: provider,
+  EthersContract: ethers.Contract,
+  account,
+};
+
+const SDKwithApprove = constructSimpleSDK(
+  { network: 1, axios },
+  providerOptions
+);
+
+// type Promise<TxHash>
+const approveTxHash = SDKwithApprove.approveToken('1000000000000', '0x...');

--- a/src/examples/web3.ts
+++ b/src/examples/web3.ts
@@ -2,7 +2,7 @@
 import axios from 'axios';
 import Web3 from 'web3';
 import {
-  constructSDK,
+  constructFullSDK,
   constructAxiosFetcher,
   constructWeb3ContractCaller,
 } from '..';
@@ -11,7 +11,7 @@ const fetcher = constructAxiosFetcher(axios);
 const web3 = new Web3(Web3.givenProvider);
 const contractCaller = constructWeb3ContractCaller(web3);
 
-const paraswap = constructSDK({
+const paraswap = constructFullSDK({
   network: 1,
   fetcher,
   contractCaller,

--- a/src/examples/web3.ts
+++ b/src/examples/web3.ts
@@ -1,13 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import axios from 'axios';
 import Web3 from 'web3';
-import { constructSDK } from '..';
-import { constructAxiosFetcher } from '../helpers';
-import { constructContractCaller } from '../helpers/web3';
+import {
+  constructSDK,
+  constructAxiosFetcher,
+  constructWeb3ContractCaller,
+} from '..';
 
 const fetcher = constructAxiosFetcher(axios);
 const web3 = new Web3(Web3.givenProvider);
-const contractCaller = constructContractCaller(web3);
+const contractCaller = constructWeb3ContractCaller(web3);
 
 const paraswap = constructSDK({
   network: 1,

--- a/src/examples/web3.ts
+++ b/src/examples/web3.ts
@@ -18,6 +18,7 @@ const paraswap = constructFullSDK({
 });
 
 async function main() {
+  // type Web3UnpromiEvent
   const eventfulTxResponse = await paraswap.approveToken(
     '1000000000000000000',
     '0xcafe001067cDEF266AfB7Eb5A286dCFD277f3dE5'

--- a/src/helpers/fetchers/axios.ts
+++ b/src/helpers/fetchers/axios.ts
@@ -1,9 +1,9 @@
-import { FetcherFunction } from '../types';
-import type Axios from 'axios';
-import { FetcherError } from './misc';
+import type { FetcherFunction } from '../../types';
+import type AxiosStatic from 'axios';
+import { FetcherError } from '../misc';
 
 export const constructFetcher =
-  (axios: typeof Axios): FetcherFunction =>
+  (axios: typeof AxiosStatic): FetcherFunction =>
   async (params) => {
     try {
       const { data } = await axios.request(params);

--- a/src/helpers/fetchers/fetch.ts
+++ b/src/helpers/fetchers/fetch.ts
@@ -1,5 +1,5 @@
-import { FetcherFunction } from '../types';
-import { FetcherError } from './misc';
+import type { FetcherFunction } from '../../types';
+import { FetcherError } from '../misc';
 
 // @TODO may not work with node-fetch
 type Fetch = typeof fetch;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,8 +1,11 @@
-export { constructFetcher as constructAxiosFetcher } from './axios';
-export { constructFetcher as constructFetchFetcher } from './fetch';
-export { constructContractCaller as constructEthersContractCaller } from './ethers';
+export { constructFetcher as constructAxiosFetcher } from './fetchers/axios';
+export { constructFetcher as constructFetchFetcher } from './fetchers/fetch';
+export {
+  constructContractCaller as constructEthersContractCaller,
+  EthersProviderDeps,
+} from './providers/ethers';
 export {
   constructContractCaller as constructWeb3ContractCaller,
-  UnpromiEvent as Web3UnpromiEvent,
-} from './web3';
+  Web3UnpromiEvent,
+} from './providers/web3';
 export { isFetcherError } from './misc';

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,38 +1,67 @@
 import type {
-  Contract,
-  ContractFunction,
-  PopulatedTransaction,
-  BigNumber,
+  Contract as EthersContract,
+  ContractFunction as EthersContractFunction,
+  PopulatedTransaction as EthersPopulatedTransaction,
+  BigNumber as EthersBigNumber,
 } from 'ethers';
+import type {
+  ContractSendMethod as Web3ContractSendMethod,
+  Contract as Web3Contract,
+} from 'web3-eth-contract';
 import { assert } from 'ts-essentials';
 
 import type { AxiosError } from 'axios';
 
-export type ContractWithMethod<T extends string> = Contract & {
-  readonly [method in T]: ContractFunction;
+export type EthersContractWithMethod<T extends string> = EthersContract & {
+  readonly [method in T]: EthersContractFunction;
 } & {
-  readonly functions: { [method in T]: ContractFunction };
+  readonly functions: { [method in T]: EthersContractFunction };
 
-  readonly callStatic: { [method in T]: ContractFunction };
-  readonly estimateGas: { [method in T]: ContractFunction<BigNumber> };
+  readonly callStatic: { [method in T]: EthersContractFunction };
+  readonly estimateGas: {
+    [method in T]: EthersContractFunction<EthersBigNumber>;
+  };
   readonly populateTransaction: {
-    [method in T]: ContractFunction<PopulatedTransaction>;
+    [method in T]: EthersContractFunction<EthersPopulatedTransaction>;
   };
 };
 
-export function contractHasMethods<T extends string>(
-  contract: Contract,
+export function ethersContractHasMethods<T extends string>(
+  contract: EthersContract,
   ...methods: T[]
-): contract is ContractWithMethod<T> {
+): contract is EthersContractWithMethod<T> {
   return methods.every((method) => typeof contract[method] === 'function');
 }
 
-export function assertContractHasMethods<T extends string>(
-  contract: Contract,
+export function assertEthersContractHasMethods<T extends string>(
+  contract: EthersContract,
   ...methods: T[]
-): asserts contract is ContractWithMethod<T> {
+): asserts contract is EthersContractWithMethod<T> {
   assert(
-    contractHasMethods(contract, ...methods),
+    ethersContractHasMethods(contract, ...methods),
+    `Contract must have methods: ${methods.join(', ')}`
+  );
+}
+
+export type Web3ContractWithMethod<T extends string> = Web3Contract & {
+  methods: { [method in T]: Web3ContractSendMethod };
+};
+
+export function web3ContractHasMethods<T extends string>(
+  contract: Web3Contract,
+  ...methods: T[]
+): contract is Web3ContractWithMethod<T> {
+  return methods.every(
+    (method) => typeof contract.methods[method] === 'function'
+  );
+}
+
+export function assertWeb3ContractHasMethods<T extends string>(
+  contract: Web3Contract,
+  ...methods: T[]
+): asserts contract is Web3ContractWithMethod<T> {
+  assert(
+    web3ContractHasMethods(contract, ...methods),
     `Contract must have methods: ${methods.join(', ')}`
   );
 }

--- a/src/helpers/providers/ethers.ts
+++ b/src/helpers/providers/ethers.ts
@@ -17,12 +17,15 @@ import { assertEthersContractHasMethods } from '../misc';
 import { assert } from 'ts-essentials';
 
 export interface EthersProviderDeps {
-  providerOrSigner: BaseProvider | Signer;
-  Contract: typeof EthersContract; // passing Contract in allows not to include ethers as dependency even when using legacy ParaSwap class
+  ethersProviderOrSigner: BaseProvider | Signer;
+  EthersContract: typeof EthersContract; // passing Contract in allows not to include ethers as dependency even when using legacy ParaSwap class
 }
 
 export const constructContractCaller = (
-  { providerOrSigner, Contract }: EthersProviderDeps,
+  {
+    ethersProviderOrSigner: providerOrSigner,
+    EthersContract: Contract,
+  }: EthersProviderDeps,
   account?: Address
 ): ContractCallerFunctions<ContractTransaction> => {
   const staticCall: StaticContractCallerFn = async (params) => {

--- a/src/helpers/providers/ethers.ts
+++ b/src/helpers/providers/ethers.ts
@@ -4,7 +4,7 @@ import type {
   NoExtraKeysCheck,
   StaticContractCallerFn,
   TransactionContractCallerFn,
-} from '../types';
+} from '../../types';
 import type { JsonRpcProvider, BaseProvider } from '@ethersproject/providers';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type {
@@ -13,10 +13,10 @@ import type {
   CallOverrides,
   ContractTransaction,
 } from '@ethersproject/contracts';
-import { assertContractHasMethods } from '../helpers/misc';
+import { assertContractHasMethods } from '../misc';
 import { assert } from 'ts-essentials';
 
-interface EthersProviderDeps {
+export interface EthersProviderDeps {
   providerOrSigner: BaseProvider | Signer;
   Contract: typeof EthersContract; // passing Contract in allows not to include ethers as dependency even when using legacy ParaSwap class
 }

--- a/src/helpers/providers/ethers.ts
+++ b/src/helpers/providers/ethers.ts
@@ -13,7 +13,7 @@ import type {
   CallOverrides,
   ContractTransaction,
 } from '@ethersproject/contracts';
-import { assertContractHasMethods } from '../misc';
+import { assertEthersContractHasMethods } from '../misc';
 import { assert } from 'ts-essentials';
 
 export interface EthersProviderDeps {
@@ -30,7 +30,7 @@ export const constructContractCaller = (
 
     const contract = new Contract(address, abi, providerOrSigner);
 
-    assertContractHasMethods(contract, contractMethod);
+    assertEthersContractHasMethods(contract, contractMethod);
     // drop keys not in CallOverrides
     const { block, gas, ...restOverrides } = overrides;
     // reassign values to keys in CallOverrides
@@ -72,7 +72,7 @@ export const constructContractCaller = (
 
     const contract = new Contract(address, abi, signer);
 
-    assertContractHasMethods(contract, contractMethod);
+    assertEthersContractHasMethods(contract, contractMethod);
     // drop keys not in PayableOverrides
     const { gas, from, ...restOverrides } = overrides;
     // reassign values to keys in PayableOverrides

--- a/src/helpers/providers/web3.ts
+++ b/src/helpers/providers/web3.ts
@@ -3,7 +3,7 @@ import type {
   ContractCallerFunctions,
   StaticContractCallerFn,
   TransactionContractCallerFn,
-} from '../types';
+} from '../../types';
 import type Web3 from 'web3';
 import type { AbiItem } from 'web3-utils';
 import type {
@@ -14,14 +14,14 @@ import type {
 } from 'web3-eth-contract';
 import type { PromiEvent } from 'web3-core';
 import { assert } from 'ts-essentials';
-import { assertContractHasMethods } from './misc';
+import { assertContractHasMethods } from '../misc';
 
-export type UnpromiEvent = Pick<PromiEvent<Contract>, 'on' | 'once'>;
+export type Web3UnpromiEvent = Pick<PromiEvent<Contract>, 'on' | 'once'>;
 
 export const constructContractCaller = (
   web3: Web3,
   account?: Address
-): ContractCallerFunctions<UnpromiEvent> => {
+): ContractCallerFunctions<Web3UnpromiEvent> => {
   const staticCall: StaticContractCallerFn = async (params) => {
     assert(web3.currentProvider, 'web3.currentProvider is not set');
 
@@ -44,7 +44,7 @@ export const constructContractCaller = (
     return contract.methods[contractMethod](...args).call(normalizedOverrides);
   };
 
-  const transactCall: TransactionContractCallerFn<UnpromiEvent> = async (
+  const transactCall: TransactionContractCallerFn<Web3UnpromiEvent> = async (
     params
   ) => {
     assert(web3.currentProvider, 'web3.currentProvider is not set');
@@ -84,7 +84,7 @@ export const constructContractCaller = (
     // that is await Promise<PromiEvent> = Awaited<PromiEvent> that doesn't have .on|once
     // so that functionality becomes lost
     // transactCall can be made sync, but approve has to be async to await getSpender()
-    const unpromiEvent: UnpromiEvent = {
+    const unpromiEvent: Web3UnpromiEvent = {
       on: promiEvent.on.bind(promiEvent),
       once: promiEvent.once.bind(promiEvent),
     };

--- a/src/helpers/providers/web3.ts
+++ b/src/helpers/providers/web3.ts
@@ -14,7 +14,7 @@ import type {
 } from 'web3-eth-contract';
 import type { PromiEvent } from 'web3-core';
 import { assert } from 'ts-essentials';
-import { assertContractHasMethods } from '../misc';
+import { assertWeb3ContractHasMethods } from '../misc';
 
 export type Web3UnpromiEvent = Pick<PromiEvent<Contract>, 'on' | 'once'>;
 
@@ -32,7 +32,7 @@ export const constructContractCaller = (
       address
     );
 
-    assertContractHasMethods(contract.methods, contractMethod); // FIXME: web3.contract.methods is any and assert works with ethers types
+    assertWeb3ContractHasMethods(contract, contractMethod);
 
     const { block, gas, ...restOverrides } = overrides;
 
@@ -59,7 +59,7 @@ export const constructContractCaller = (
       address
     );
 
-    assertContractHasMethods(contract.methods, contractMethod); // FIXME see up
+    assertWeb3ContractHasMethods(contract, contractMethod);
 
     const { gas, from, ...restOverrides } = overrides;
 

--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -1,6 +1,4 @@
 import type { MarkOptional } from 'ts-essentials';
-import { API_URL } from './constants';
-import type { ConstructFetchInput, TokensApiResponse } from './types';
 
 /**
  * @type hex token or account address
@@ -74,31 +72,4 @@ export const constructToken = (tokenProps: ConstructTokenInput): Token => {
     network,
     ...rest,
   };
-};
-
-type GetTokens = (signal?: AbortSignal) => Promise<Token[]>;
-
-export type GetTokensFunctions = {
-  getTokens: GetTokens;
-};
-
-export const constructGetTokens = ({
-  apiURL = API_URL,
-  network,
-  fetcher,
-}: ConstructFetchInput): GetTokensFunctions => {
-  const fetchURL = `${apiURL}/tokens/${network}`;
-
-  const getTokens: GetTokens = async (signal) => {
-    const data = await fetcher<TokensApiResponse>({
-      url: fetchURL,
-      method: 'GET',
-      signal,
-    });
-
-    const tokens = data.tokens.map(constructToken);
-    return tokens;
-  };
-
-  return { getTokens };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ import {
   AddressOrSymbol,
   Token,
   PriceString,
+  TxHash,
+  TxSendOverrides,
 } from './types';
 
 export type { TransactionParams } from './methods/transaction';
@@ -69,10 +71,12 @@ export type {
   Address,
   AddressOrSymbol,
   PriceString,
+  TxHash,
+  TxSendOverrides,
 };
 
 export { SDKConfig, constructPartialSDK } from './sdk/partial';
-export { AllSDKMethods, constructFullSDK as constructSDK } from './sdk/full';
-export { SDKFetchMethods, constructFetchSDK } from './sdk/fetchOnly';
+export { AllSDKMethods, constructFullSDK } from './sdk/full';
+export { SDKFetchMethods, constructSimpleSDK } from './sdk/simple';
 
 export { ParaSwap } from './legacy';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,36 @@
-import { constructApproveToken, ApproveTokenFunctions } from './approve';
-import { constructGetBalances, GetBalancesFunctions } from './balance';
-import { constructGetSpender, GetSpenderFunctions } from './spender';
-import { constructGetAdapters, AdaptersFunctions } from './adapters';
-import { constructGetRate, GetRateFunctions } from './rates';
 import {
-  constructGetTokens,
-  constructToken,
-  GetTokensFunctions,
-  Token,
-  PriceString,
-} from './token';
-import { BuildTxFunctions, constructBuildTx } from './transaction';
+  constructApproveToken,
+  ApproveTokenFunctions,
+} from './methods/approve';
+import {
+  constructGetBalances,
+  GetBalancesFunctions,
+  isAllowance,
+  Allowance,
+} from './methods/balance';
+import { constructGetSpender, GetSpenderFunctions } from './methods/spender';
+import { constructGetAdapters, GetAdaptersFunctions } from './methods/adapters';
+import { constructGetRate, GetRateFunctions } from './methods/rates';
+import { constructGetTokens, GetTokensFunctions } from './methods/token';
+import { BuildTxFunctions, constructBuildTx } from './methods/transaction';
 import {
   constructEthersContractCaller,
   constructWeb3ContractCaller,
   constructAxiosFetcher,
   constructFetchFetcher,
   isFetcherError,
+  EthersProviderDeps,
 } from './helpers';
 import {
-  ConstructBaseInput,
   ConstructFetchInput,
   ConstructProviderFetchInput,
   Address,
+  AddressOrSymbol,
+  Token,
+  PriceString,
 } from './types';
-import { UnionToIntersection } from 'ts-essentials';
 
-export type { TransactionParams } from './transaction';
+export type { TransactionParams } from './methods/transaction';
 export type { Web3UnpromiEvent } from './helpers';
 export * from './constants';
 
@@ -43,98 +47,32 @@ export {
   constructWeb3ContractCaller,
   constructAxiosFetcher,
   constructFetchFetcher,
-  constructToken,
   constructGetAdapters,
   constructGetRate,
   isFetcherError,
+  isAllowance,
 };
 
 export type {
+  Allowance,
+  EthersProviderDeps,
   ApproveTokenFunctions,
   GetBalancesFunctions,
   GetSpenderFunctions,
   GetTokensFunctions,
+  GetAdaptersFunctions,
+  GetRateFunctions,
   BuildTxFunctions,
   ConstructFetchInput,
   ConstructProviderFetchInput,
-  AdaptersFunctions as ConstructAdaptersFunctions,
   Token,
   Address,
+  AddressOrSymbol,
   PriceString,
 };
 
-export type SDKConfig<TxResponse = any> = ConstructProviderFetchInput<
-  TxResponse,
-  'transactCall'
-> &
-  ConstructFetchInput;
-
-export type AllSDKMethods<TxResponse> = GetBalancesFunctions &
-  GetTokensFunctions &
-  GetSpenderFunctions &
-  ApproveTokenFunctions<TxResponse> &
-  BuildTxFunctions &
-  AdaptersFunctions &
-  GetRateFunctions;
-
-type AnyFunction = (...args: any[]) => any;
-
-type SDKFunction<T extends ConstructBaseInput> = (
-  config: T
-) => Record<string, AnyFunction>;
-
-type IntersectionOfReturns<Funcs extends AnyFunction[]> = UnionToIntersection<
-  ReturnType<Funcs[number]>
->;
-
-type ApproveTokenFunctionsKeys = keyof ApproveTokenFunctions<any>;
-
-type PartialSDKResult<
-  Config extends ConstructBaseInput,
-  Funcs extends [SDKFunction<Config>, ...SDKFunction<Config>[]]
-> = IntersectionOfReturns<Funcs> extends ApproveTokenFunctions<any> // if there are ApproveTokenFunctions in the intersection
-  ? // which means constructApproveToken was passed in Funcs
-    Omit<IntersectionOfReturns<Funcs>, ApproveTokenFunctionsKeys> &
-      ApproveTokenFunctions<
-        // infer what TxResponse was used in Config
-        Config extends SDKConfig<infer TxResponse> ? TxResponse : unknown
-        // and make the ApproveTokenFunctions<unknow> in the intersection a specific ApproveTokenFunctions<TxResponse>
-      >
-  : IntersectionOfReturns<Funcs>;
-
-export const constructPartialSDK = <
-  Config extends ConstructBaseInput,
-  Funcs extends [SDKFunction<Config>, ...SDKFunction<Config>[]]
->(
-  config: Config, // config is auto-inferred to cover the used functions
-  ...funcs: Funcs
-): PartialSDKResult<Config, Funcs> => {
-  const sdkFuncs = funcs.reduce<Partial<IntersectionOfReturns<Funcs>>>(
-    (accum, func) => {
-      const sdkSlice = func(config);
-      return Object.assign(accum, sdkSlice);
-    },
-    {}
-  );
-
-  return sdkFuncs as PartialSDKResult<Config, Funcs>;
-};
-
-export const constructSDK = <TxResponse = any>(
-  config: SDKConfig<TxResponse>
-): AllSDKMethods<TxResponse> =>
-  // include all available functions
-  constructPartialSDK(
-    config,
-    constructGetBalances,
-    constructGetTokens,
-    constructGetSpender,
-    constructApproveToken as (
-      options: ConstructProviderFetchInput<TxResponse, 'transactCall'>
-    ) => ApproveTokenFunctions<TxResponse>, // @TODO try Instantiation Expression when TS 4.7 `as constructApproveToken<TxResponse>`
-    constructBuildTx,
-    constructGetAdapters,
-    constructGetRate
-  );
+export { SDKConfig, constructPartialSDK } from './sdk/partial';
+export { AllSDKMethods, constructFullSDK as constructSDK } from './sdk/full';
+export { SDKFetchMethods, constructFetchSDK } from './sdk/fetchOnly';
 
 export { ParaSwap } from './legacy';

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -1,12 +1,7 @@
 import type { AxiosStatic } from 'axios';
 import type Web3 from 'web3';
 import type { SendOptions } from 'web3-eth-contract';
-import type { Contract as EthersContract } from '@ethersproject/contracts';
-import type { Signer } from '@ethersproject/abstract-signer';
-
-import type { BaseProvider } from '@ethersproject/providers';
 import type { ContractTransaction } from '@ethersproject/contracts';
-
 import type { Address, OptimalRate } from 'paraswap-core';
 
 import { API_URL, SwapSide } from '../constants';
@@ -29,14 +24,14 @@ import {
   constructEthersContractCaller,
   constructWeb3ContractCaller,
   isFetcherError,
+  Web3UnpromiEvent,
+  EthersProviderDeps,
 } from '../helpers';
 
-import type { RateOptions } from '../rates';
-import type { BuildOptions, TransactionParams } from '../transaction';
-import type { AddressOrSymbol, Token } from '../token';
-import type { Allowance } from '../balance';
-import type { FetcherFunction } from '../types';
-import type { UnpromiEvent } from '../helpers/web3';
+import type { RateOptions } from '../methods/rates';
+import type { BuildOptions, TransactionParams } from '../methods/transaction';
+import type { AddressOrSymbol, Token, FetcherFunction } from '../types';
+import type { Allowance } from '../methods/balance';
 
 export type APIError = {
   message: string;
@@ -45,12 +40,7 @@ export type APIError = {
 };
 type Fetch = typeof fetch;
 
-interface EthersProviderDeps {
-  providerOrSigner: BaseProvider | Signer;
-  Contract: typeof EthersContract;
-}
-
-type TxResponse = UnpromiEvent | ContractTransaction;
+type TxResponse = Web3UnpromiEvent | ContractTransaction;
 
 /** @deprecated */
 export class ParaSwap {

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -14,7 +14,7 @@ import {
   constructGetTokens,
   constructPartialSDK,
   constructGetRate,
-  constructSDK,
+  constructFullSDK,
   PriceString,
 } from '..';
 import { assert } from 'ts-essentials';
@@ -86,7 +86,7 @@ export class ParaSwap {
       : null;
 
     if (contractCaller) {
-      this.sdk = constructSDK<TxResponse>({
+      this.sdk = constructFullSDK<TxResponse>({
         fetcher,
         contractCaller,
         apiURL,
@@ -128,7 +128,7 @@ export class ParaSwap {
     const contractCaller = constructWeb3ContractCaller(web3Provider, account);
     const { apiURL, network, fetcher } = this;
 
-    this.sdk = constructSDK({
+    this.sdk = constructFullSDK({
       fetcher,
       contractCaller,
       apiURL,
@@ -146,7 +146,7 @@ export class ParaSwap {
     const contractCaller = constructEthersContractCaller(ethersDeps, account);
     const { apiURL, network, fetcher } = this;
 
-    this.sdk = constructSDK({
+    this.sdk = constructFullSDK({
       fetcher,
       contractCaller,
       apiURL,

--- a/src/methods/adapters.ts
+++ b/src/methods/adapters.ts
@@ -1,6 +1,6 @@
-import { ConstructFetchInput } from './types';
-import { constructSearchString } from './helpers/misc';
-import { API_URL } from './constants';
+import { ConstructFetchInput } from '../types';
+import { constructSearchString } from '../helpers/misc';
+import { API_URL } from '../constants';
 
 type Adapter = {
   adapter: string;
@@ -20,7 +20,7 @@ export type AllAdaptersOptions =
   | OptionsList
   | OptionsListNamesOnly;
 
-interface GetAdapternsFunc {
+interface GetAdaptersFunc {
   (options: OptionsObject, signal?: AbortSignal): Promise<AdaptersAsObject>;
   (options: OptionsList, signal?: AbortSignal): Promise<AdaptersAsList>;
   (
@@ -32,15 +32,15 @@ interface GetAdapternsFunc {
   >;
 }
 
-export type AdaptersFunctions = {
-  getAdapters: GetAdapternsFunc;
+export type GetAdaptersFunctions = {
+  getAdapters: GetAdaptersFunc;
 };
 
 export const constructGetAdapters = ({
   apiURL = API_URL,
   network,
   fetcher,
-}: ConstructFetchInput): AdaptersFunctions => {
+}: ConstructFetchInput): GetAdaptersFunctions => {
   async function getAdapters(
     options: OptionsObject,
     signal?: AbortSignal

--- a/src/methods/approve.ts
+++ b/src/methods/approve.ts
@@ -1,6 +1,10 @@
 import { constructGetSpender } from './spender';
-import type { Address, PriceString } from './token';
-import type { ConstructProviderFetchInput, TxSendOverrides } from './types';
+import type {
+  ConstructProviderFetchInput,
+  TxSendOverrides,
+  Address,
+  PriceString,
+} from '../types';
 
 type ApproveToken<T> = (
   amount: PriceString,

--- a/src/methods/balance.ts
+++ b/src/methods/balance.ts
@@ -1,10 +1,15 @@
-import { API_URL } from './constants';
-import { Token, Address, constructToken, AddressOrSymbol } from './token';
+import { API_URL } from '../constants';
+import {
+  Token,
+  Address,
+  constructToken,
+  AddressOrSymbol,
+} from '../helpers/token';
 import {
   ConstructFetchInput,
   TokenApiResponse,
   TokensApiResponse,
-} from './types';
+} from '../types';
 
 type GetBalances = (
   userAddress: Address,

--- a/src/methods/rates.ts
+++ b/src/methods/rates.ts
@@ -1,8 +1,13 @@
 import { OptimalRate } from 'paraswap-core';
-import { SwapSide, ContractMethod, API_URL } from './constants';
-import { constructSearchString } from './helpers/misc';
-import { Address, AddressOrSymbol, PriceString } from './token';
-import { ConstructFetchInput, PriceRouteApiResponse } from './types';
+import { SwapSide, ContractMethod, API_URL } from '../constants';
+import { constructSearchString } from '../helpers/misc';
+import {
+  ConstructFetchInput,
+  PriceRouteApiResponse,
+  Address,
+  AddressOrSymbol,
+  PriceString,
+} from '../types';
 
 // TODO: This is legacy and can be removed
 export enum PricingMethod {

--- a/src/methods/spender.ts
+++ b/src/methods/spender.ts
@@ -1,6 +1,5 @@
-import { API_URL } from './constants';
-import { Address } from './token';
-import { ConstructFetchInput } from './types';
+import { API_URL } from '../constants';
+import { ConstructFetchInput, Address } from '../types';
 
 type GetSpender = (signal?: AbortSignal) => Promise<Address>;
 

--- a/src/methods/token.ts
+++ b/src/methods/token.ts
@@ -1,0 +1,30 @@
+import { API_URL } from '../constants';
+import { constructToken } from '../helpers/token';
+import type { ConstructFetchInput, Token, TokensApiResponse } from '../types';
+
+type GetTokens = (signal?: AbortSignal) => Promise<Token[]>;
+
+export type GetTokensFunctions = {
+  getTokens: GetTokens;
+};
+
+export const constructGetTokens = ({
+  apiURL = API_URL,
+  network,
+  fetcher,
+}: ConstructFetchInput): GetTokensFunctions => {
+  const fetchURL = `${apiURL}/tokens/${network}`;
+
+  const getTokens: GetTokens = async (signal) => {
+    const data = await fetcher<TokensApiResponse>({
+      url: fetchURL,
+      method: 'GET',
+      signal,
+    });
+
+    const tokens = data.tokens.map(constructToken);
+    return tokens;
+  };
+
+  return { getTokens };
+};

--- a/src/methods/transaction.ts
+++ b/src/methods/transaction.ts
@@ -1,11 +1,15 @@
 import type { OptimalRate } from 'paraswap-core';
-import type { WithGasPrice, WithMaxFee } from './gas';
-import type { ConstructFetchInput, Address, FetcherPostInput } from './types';
+import type { WithGasPrice, WithMaxFee } from '../gas';
+import type {
+  ConstructFetchInput,
+  Address,
+  FetcherPostInput,
+  PriceString,
+} from '../types';
 
 import { assert } from 'ts-essentials';
-import { API_URL, SwapSide } from './constants';
-import { PriceString } from './token';
-import { constructSearchString } from './helpers/misc';
+import { API_URL, SwapSide } from '../constants';
+import { constructSearchString } from '../helpers/misc';
 
 export interface TransactionParams {
   to: string;

--- a/src/sdk/full.ts
+++ b/src/sdk/full.ts
@@ -1,0 +1,41 @@
+import {
+  constructApproveToken,
+  ApproveTokenFunctions,
+} from '../methods/approve';
+import { constructGetBalances, GetBalancesFunctions } from '../methods/balance';
+import { constructGetSpender, GetSpenderFunctions } from '../methods/spender';
+import {
+  constructGetAdapters,
+  GetAdaptersFunctions,
+} from '../methods/adapters';
+import { constructGetRate, GetRateFunctions } from '../methods/rates';
+import { constructGetTokens, GetTokensFunctions } from '../methods/token';
+import { constructBuildTx, BuildTxFunctions } from '../methods/transaction';
+import { constructPartialSDK, SDKConfig } from './partial';
+import type { ConstructProviderFetchInput } from '../types';
+
+export type AllSDKMethods<TxResponse> = GetBalancesFunctions &
+  GetTokensFunctions &
+  GetSpenderFunctions &
+  ApproveTokenFunctions<TxResponse> &
+  BuildTxFunctions &
+  GetAdaptersFunctions &
+  GetRateFunctions;
+
+/** @description construct SDK with every method, fetching from API and token approval */
+export const constructFullSDK = <TxResponse = any>(
+  config: SDKConfig<TxResponse>
+): AllSDKMethods<TxResponse> =>
+  // include all available functions
+  constructPartialSDK(
+    config,
+    constructGetBalances,
+    constructGetTokens,
+    constructGetSpender,
+    constructApproveToken as (
+      options: ConstructProviderFetchInput<TxResponse, 'transactCall'>
+    ) => ApproveTokenFunctions<TxResponse>, // @TODO try Instantiation Expression when TS 4.7 `as constructApproveToken<TxResponse>`
+    constructBuildTx,
+    constructGetAdapters,
+    constructGetRate
+  );

--- a/src/sdk/partial.ts
+++ b/src/sdk/partial.ts
@@ -1,0 +1,57 @@
+import { ApproveTokenFunctions } from '../methods/approve';
+import {
+  ConstructBaseInput,
+  ConstructFetchInput,
+  ConstructProviderFetchInput,
+} from '../types';
+import { UnionToIntersection } from 'ts-essentials';
+
+export type SDKConfig<TxResponse = any> = ConstructProviderFetchInput<
+  TxResponse,
+  'transactCall'
+> &
+  ConstructFetchInput;
+
+type AnyFunction = (...args: any[]) => any;
+
+type SDKFunction<T extends ConstructBaseInput> = (
+  config: T
+) => Record<string, AnyFunction>;
+
+type IntersectionOfReturns<Funcs extends AnyFunction[]> = UnionToIntersection<
+  ReturnType<Funcs[number]>
+>;
+
+type ApproveTokenFunctionsKeys = keyof ApproveTokenFunctions<any>;
+
+type PartialSDKResult<
+  Config extends ConstructBaseInput,
+  Funcs extends [SDKFunction<Config>, ...SDKFunction<Config>[]]
+> = IntersectionOfReturns<Funcs> extends ApproveTokenFunctions<any> // if there are ApproveTokenFunctions in the intersection
+  ? // which means constructApproveToken was passed in Funcs
+    Omit<IntersectionOfReturns<Funcs>, ApproveTokenFunctionsKeys> &
+      ApproveTokenFunctions<
+        // infer what TxResponse was used in Config
+        Config extends SDKConfig<infer TxResponse> ? TxResponse : unknown
+        // and make the ApproveTokenFunctions<unknow> in the intersection a specific ApproveTokenFunctions<TxResponse>
+      >
+  : IntersectionOfReturns<Funcs>;
+
+/** @description construct composable SDK with methods you choose yourself */
+export const constructPartialSDK = <
+  Config extends ConstructBaseInput,
+  Funcs extends [SDKFunction<Config>, ...SDKFunction<Config>[]]
+>(
+  config: Config, // config is auto-inferred to cover the used functions
+  ...funcs: Funcs
+): PartialSDKResult<Config, Funcs> => {
+  const sdkFuncs = funcs.reduce<Partial<IntersectionOfReturns<Funcs>>>(
+    (accum, func) => {
+      const sdkSlice = func(config);
+      return Object.assign(accum, sdkSlice);
+    },
+    {}
+  );
+
+  return sdkFuncs as PartialSDKResult<Config, Funcs>;
+};

--- a/src/sdk/simple.ts
+++ b/src/sdk/simple.ts
@@ -1,0 +1,138 @@
+import { constructPartialSDK, SDKConfig } from './partial';
+import {
+  GetAdaptersFunctions,
+  constructGetAdapters,
+} from '../methods/adapters';
+import { GetBalancesFunctions, constructGetBalances } from '../methods/balance';
+import { GetRateFunctions, constructGetRate } from '../methods/rates';
+import { GetSpenderFunctions, constructGetSpender } from '../methods/spender';
+import { GetTokensFunctions, constructGetTokens } from '../methods/token';
+import { BuildTxFunctions, constructBuildTx } from '../methods/transaction';
+
+import {
+  constructAxiosFetcher,
+  constructFetchFetcher,
+  constructEthersContractCaller,
+  constructWeb3ContractCaller,
+} from '../helpers';
+
+import type {
+  ConstructBaseInput,
+  ConstructFetchInput,
+  ContractCallerFunctions,
+  TransactionContractCallerFn,
+  TxHash,
+  Address,
+} from '../types';
+
+import type { EthersProviderDeps } from '../helpers';
+import type Web3 from 'web3';
+
+import type AxiosStatic from 'axios';
+import { AllSDKMethods, constructFullSDK } from './full';
+
+export type SDKFetchMethods = GetBalancesFunctions &
+  GetTokensFunctions &
+  GetSpenderFunctions &
+  BuildTxFunctions &
+  GetAdaptersFunctions &
+  GetRateFunctions;
+
+type SimpleOptions = ConstructBaseInput &
+  (
+    | {
+        axios: typeof AxiosStatic;
+      }
+    | { fetch: typeof fetch }
+  );
+
+type ProviderOptions = (EthersProviderDeps | { web3: Web3 }) & {
+  account: Address;
+};
+
+/** @description construct SDK with methods that fetch from API and optionally with token approval methods */
+export function constructSimpleSDK(options: SimpleOptions): SDKFetchMethods;
+export function constructSimpleSDK(
+  options: SimpleOptions,
+  providerOptions: ProviderOptions
+): AllSDKMethods<TxHash>;
+export function constructSimpleSDK(
+  options: SimpleOptions,
+  providerOptions?: ProviderOptions
+): SDKFetchMethods | AllSDKMethods<TxHash> {
+  const fetcher =
+    'axios' in options
+      ? constructAxiosFetcher(options.axios)
+      : constructFetchFetcher(options.fetch);
+
+  if (!providerOptions) {
+    const config: ConstructFetchInput = {
+      apiURL: options.apiURL,
+      network: options.network,
+      fetcher,
+    };
+
+    // include all available functions that don't need `contractCaller`
+    const sdk: SDKFetchMethods = constructPartialSDK(
+      config,
+      constructGetBalances,
+      constructGetTokens,
+      constructGetSpender,
+      constructBuildTx,
+      constructGetAdapters,
+      constructGetRate
+    );
+
+    return sdk;
+  }
+
+  const contractCaller = constructSimpleContractCaller(providerOptions);
+
+  const config: SDKConfig<TxHash> = {
+    apiURL: options.apiURL,
+    network: options.network,
+    fetcher,
+    contractCaller,
+  };
+
+  const sdk: AllSDKMethods<TxHash> = constructFullSDK(config);
+
+  return sdk;
+}
+
+function constructSimpleContractCaller(
+  providerOptions: ProviderOptions
+): ContractCallerFunctions<TxHash> {
+  if ('ethersProviderOrSigner' in providerOptions) {
+    const { staticCall, transactCall: _transactCall } =
+      constructEthersContractCaller(providerOptions, providerOptions.account);
+
+    const transactCall: TransactionContractCallerFn<TxHash> = async (
+      params
+    ) => {
+      const contractTx = await _transactCall(params);
+
+      // as soon as tx is sent
+      // returning tx hash, it's up to the user to wait for tx
+      return contractTx.hash;
+    };
+
+    return { staticCall, transactCall };
+  }
+
+  const { staticCall, transactCall: _transactCall } =
+    constructWeb3ContractCaller(providerOptions.web3, providerOptions.account);
+
+  const transactCall: TransactionContractCallerFn<TxHash> = async (params) => {
+    const unpromiEvent = await _transactCall(params);
+
+    // as soon as tx is sent
+    // returning tx hash, it's up to the user to wait for tx
+    return new Promise<TxHash>((resolve, reject) => {
+      unpromiEvent.once('transactionHash', resolve);
+      unpromiEvent.once('error', reject);
+    });
+  };
+
+  return { staticCall, transactCall };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,14 @@
 import type { JsonFragment } from '@ethersproject/abi';
 import { OptimalRate } from 'paraswap-core';
-import { Address, Token, TxHash } from './token';
+import {
+  Address,
+  AddressOrSymbol,
+  PriceString,
+  Token,
+  TxHash,
+} from './helpers/token';
 
-export type { Address, Token, TxHash };
+export type { Address, AddressOrSymbol, PriceString, Token, TxHash };
 
 export interface ConstructBaseInput {
   apiURL?: string;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -239,8 +239,8 @@ describe.each([
     expect(adapters.paraswappool[0].adapter).toBeDefined();
     expect(adapters.uniswapv2[0].adapter).toBeDefined();
     expect(adapters.uniswapv2[0].index).toBeDefined();
-    expect(adapters.kyber[0].adapter).toBeDefined();
-    expect(adapters.kyber[0].index).toBeDefined();
+    expect(adapters.kyberdmm[0].adapter).toBeDefined();
+    expect(adapters.kyberdmm[0].index).toBeDefined();
   });
 
   test('Build_Tx', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -91,8 +91,8 @@ const senderAddress = signer.address;
 
 const ethersContractCaller = constructEthersContractCaller(
   {
-    providerOrSigner: signer,
-    Contract: ethers.Contract,
+    ethersProviderOrSigner: signer,
+    EthersContract: ethers.Contract,
   },
   senderAddress
 );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -23,20 +23,19 @@ import {
   GetTokensFunctions,
   SDKConfig,
   Web3UnpromiEvent,
-} from '../src';
-import BigNumber from 'bignumber.js';
-import { SwapSide } from '../src';
-import {
   constructGetBalances,
   GetBalancesFunctions,
+  GetAdaptersFunctions,
+  GetRateFunctions,
   isAllowance,
-} from '../src/balance';
-import { AdaptersFunctions } from '../src/adapters';
+  SwapSide,
+} from '../src';
+import BigNumber from 'bignumber.js';
+
 import erc20abi from './abi/ERC20.json';
 
 import ganache from 'ganache';
 import { assert } from 'ts-essentials';
-import { GetRateFunctions } from '../src/rates';
 import {
   ContractCallerFunctions,
   TransactionContractCallerFn,
@@ -113,7 +112,7 @@ describe.each([
   ['axiosFetcher', axiosFetcher],
 ])('ParaSwap SDK: fetching methods: %s', (testName, fetcher) => {
   let paraSwap: GetBalancesFunctions &
-    AdaptersFunctions &
+    GetAdaptersFunctions &
     GetTokensFunctions &
     GetRateFunctions &
     GetSpenderFunctions &

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -409,8 +409,8 @@ describe.each([
         await tx.wait(1);
       } else if ('on' in tx) {
         await new Promise<Web3TransactionReceipt>((resolve, reject) => {
-          tx.on('receipt', resolve);
-          tx.on('error', reject);
+          tx.once('receipt', resolve);
+          tx.once('error', reject);
         });
       }
       const toContract = new ethers.Contract(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -75,6 +75,7 @@ const ganacheProvider = ganache.provider({
   chain: {
     chainId: 1,
   },
+  quiet: true,
 });
 
 const web3provider = new Web3(ganacheProvider as any);

--- a/tests/legacy.test.ts
+++ b/tests/legacy.test.ts
@@ -178,8 +178,8 @@ describe('ParaSwap SDK', () => {
     expect(adapters.paraswappool[0].adapter).toBeDefined();
     expect(adapters.uniswapv2[0].adapter).toBeDefined();
     expect(adapters.uniswapv2[0].index).toBeDefined();
-    expect(adapters.kyber[0].adapter).toBeDefined();
-    expect(adapters.kyber[0].index).toBeDefined();
+    expect(adapters.kyberdmm[0].adapter).toBeDefined();
+    expect(adapters.kyberdmm[0].index).toBeDefined();
   });
 
   test('Build_Tx', async () => {

--- a/tests/legacy.test.ts
+++ b/tests/legacy.test.ts
@@ -44,6 +44,7 @@ const ganacheProvider = ganache.provider({
   chain: {
     chainId: 1,
   },
+  quiet: true,
 });
 
 const provider = new Web3(ganacheProvider as any);

--- a/tests/legacy.test.ts
+++ b/tests/legacy.test.ts
@@ -3,13 +3,11 @@ import Web3 from 'web3';
 import { ethers } from 'ethers';
 // import axios from 'axios';
 import fetch from 'isomorphic-unfetch';
-import { ParaSwap, Token } from '../src';
+import { ParaSwap, Token, Allowance, TransactionParams } from '../src';
 import BigNumber from 'bignumber.js';
 import { SwapSide } from '../src';
 import { OptimalRate, Adapters } from 'paraswap-core';
-import { Allowance } from '../src/balance';
 import { APIError } from '../src/legacy';
-import { TransactionParams } from '../src/transaction';
 import erc20abi from './abi/ERC20.json';
 
 import ganache from 'ganache';

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -182,8 +182,8 @@ describe.each([
     expect(adapters.paraswappool[0].adapter).toBeDefined();
     expect(adapters.uniswapv2[0].adapter).toBeDefined();
     expect(adapters.uniswapv2[0].index).toBeDefined();
-    expect(adapters.kyber[0].adapter).toBeDefined();
-    expect(adapters.kyber[0].index).toBeDefined();
+    expect(adapters.kyberdmm[0].adapter).toBeDefined();
+    expect(adapters.kyberdmm[0].index).toBeDefined();
   });
 
   test('Build_Tx', async () => {

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -52,6 +52,7 @@ const ganacheProvider = ganache.provider({
   chain: {
     chainId: 1,
   },
+  quiet: true,
 });
 
 const web3provider = new Web3(ganacheProvider as any);

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -1,0 +1,352 @@
+import * as dotenv from 'dotenv';
+import Web3 from 'web3';
+import { BigNumber as BigNumberEthers, ethers } from 'ethers';
+import axios from 'axios';
+import fetch from 'isomorphic-unfetch';
+import {
+  isAllowance,
+  SwapSide,
+  SDKFetchMethods,
+  AllSDKMethods,
+  TxHash,
+} from '../src';
+import BigNumber from 'bignumber.js';
+
+import erc20abi from './abi/ERC20.json';
+
+import ganache from 'ganache';
+import { assert } from 'ts-essentials';
+
+import { constructSimpleSDK } from '../src/sdk/simple';
+
+dotenv.config();
+
+jest.setTimeout(30 * 1000);
+
+declare let process: any;
+
+const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+const HEX = '0x2b591e99afe9f32eaa6214f7b7629768c40eeb39';
+
+const DUMMY_ADDRESS_FOR_TESTING_ALLOWANCES =
+  '0xb9A079479A7b0F4E7F398F7ED3946bE6d9a40E79';
+
+const PROVIDER_URL = process.env.PROVIDER_URL;
+const network = 1;
+const srcToken = ETH;
+const destToken = DAI;
+const srcAmount = (1 * 1e18).toString(); //The source amount multiplied by its decimals
+
+const referrer = 'sdk-test';
+
+const wallet = ethers.Wallet.createRandom();
+
+const ganacheProvider = ganache.provider({
+  wallet: {
+    accounts: [{ balance: 8e18, secretKey: wallet.privateKey }],
+  },
+  fork: {
+    url: PROVIDER_URL,
+  },
+  chain: {
+    chainId: 1,
+  },
+});
+
+const web3provider = new Web3(ganacheProvider as any);
+
+const ethersProvider = new ethers.providers.Web3Provider(
+  ganacheProvider as any
+);
+
+const signer = wallet.connect(ethersProvider);
+const senderAddress = signer.address;
+
+describe.each([
+  ['fetch', { fetch }],
+  ['axios', { axios }],
+])('ParaSwap SDK: fetcher made with: %s', (testName, fetcherOptions) => {
+  let paraSwap: SDKFetchMethods;
+
+  beforeAll(() => {
+    paraSwap = constructSimpleSDK({ network, ...fetcherOptions });
+  });
+  test('getBalance', async () => {
+    const balance = await paraSwap.getBalance(senderAddress, ETH);
+    expect(balance).toBeDefined();
+  });
+
+  test('Get_Markets', async () => {
+    const markets = await paraSwap.getAdapters({
+      type: 'list',
+      namesOnly: true,
+    });
+    expect(markets.length).toBeGreaterThan(15);
+  });
+
+  test('Get_Tokens', async () => {
+    const tokens = await paraSwap.getTokens();
+
+    expect(Array.isArray(tokens)).toBe(true);
+    expect(tokens.length).toBeGreaterThan(0);
+    expect(tokens[0]).toEqual(
+      expect.objectContaining({
+        symbol: expect.any(String),
+        address: expect.any(String),
+        decimals: expect.any(Number),
+      })
+    );
+  });
+
+  test('Get_Rates', async () => {
+    const priceRoute = await paraSwap.getRate({
+      srcToken: ETH,
+      destToken: DAI,
+      amount: srcAmount,
+      userAddress: senderAddress,
+      side: SwapSide.SELL,
+      options: {
+        includeDEXS: 'UniswapV2',
+        otherExchangePrices: true,
+      },
+    });
+
+    const { destAmount, bestRoute, others } = priceRoute;
+
+    expect(typeof destAmount).toBe('string');
+
+    expect(Array.isArray(bestRoute)).toBe(true);
+
+    const swapExchange = bestRoute[0]?.swaps[0]?.swapExchanges[0];
+
+    expect(swapExchange).toBeDefined();
+
+    expect(typeof swapExchange.destAmount).toBe('string');
+    expect(new BigNumber(swapExchange.destAmount).isNaN()).toBe(false);
+
+    expect(typeof swapExchange.exchange).toBe('string');
+
+    expect(typeof bestRoute[0].percent).toBe('number');
+    expect(new BigNumber(bestRoute[0].percent).isNaN()).toBe(false);
+
+    expect(typeof swapExchange.srcAmount).toBe('string');
+    expect(new BigNumber(swapExchange.srcAmount).isNaN()).toBe(false);
+
+    expect(Array.isArray(others)).toBe(true);
+
+    const firstRoute = others?.[0];
+
+    assert(firstRoute, 'at least one route must exist');
+
+    expect(typeof firstRoute.exchange).toBe('string');
+
+    expect(typeof firstRoute.unit).toBe('string');
+    expect(firstRoute.unit && new BigNumber(firstRoute.unit).isNaN()).toBe(
+      false
+    );
+  });
+
+  test('Get_Spender', async () => {
+    const spender = await paraSwap.getSpender();
+    expect(web3provider.utils.isAddress(spender));
+  });
+
+  test('Get_Allowance', async () => {
+    const allowance = await paraSwap.getAllowance(
+      DUMMY_ADDRESS_FOR_TESTING_ALLOWANCES,
+      DAI
+    );
+
+    assert(isAllowance(allowance), 'hardcoded dummy address should be found');
+
+    expect(allowance.allowance).toEqual('123000000000000000');
+  });
+
+  test('Get_Allowances', async () => {
+    const allowances = await paraSwap.getAllowances(
+      DUMMY_ADDRESS_FOR_TESTING_ALLOWANCES,
+      [DAI, HEX]
+    );
+
+    const [daiAllowance, hexAllowance] = await Promise.all(
+      allowances.map((allowance) => allowance.allowance)
+    );
+    expect(daiAllowance).toEqual('123000000000000000');
+    expect(hexAllowance).toEqual('32100000');
+  });
+
+  test('Get_Adapters', async () => {
+    const adapters = await paraSwap.getAdapters({ type: 'object' });
+    expect(adapters.paraswappool[0].adapter).toBeDefined();
+    expect(adapters.uniswapv2[0].adapter).toBeDefined();
+    expect(adapters.uniswapv2[0].index).toBeDefined();
+    expect(adapters.kyber[0].adapter).toBeDefined();
+    expect(adapters.kyber[0].index).toBeDefined();
+  });
+
+  test('Build_Tx', async () => {
+    const destToken = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const priceRoute = await paraSwap.getRate({
+      srcToken,
+      destToken,
+      amount: srcAmount,
+      userAddress: senderAddress,
+      side: SwapSide.SELL,
+      options: {
+        includeDEXS: 'UniswapV2',
+      },
+    });
+
+    const destAmount = new BigNumber(priceRoute.destAmount)
+      .times(0.99)
+      .toFixed(0);
+
+    const txParams = await paraSwap.buildTx(
+      {
+        srcToken,
+        destToken,
+        srcAmount,
+        destAmount,
+        priceRoute,
+        userAddress: senderAddress,
+        partner: referrer,
+      },
+      { ignoreChecks: true }
+    );
+
+    expect(typeof txParams).toBe('object');
+  });
+  test('Build_and_Send_Tx', async () => {
+    const priceRoute = await paraSwap.getRate({
+      srcToken,
+      destToken,
+      amount: srcAmount,
+      userAddress: senderAddress,
+      side: SwapSide.SELL,
+      options: {
+        includeDEXS: 'Uniswap,UniswapV2,Balancer,Oasis',
+      },
+    });
+
+    const destAmount = new BigNumber(priceRoute.destAmount)
+      .times(0.99)
+      .toFixed(0);
+
+    const txParams = await paraSwap.buildTx(
+      {
+        srcToken,
+        destToken,
+        srcAmount,
+        destAmount,
+        priceRoute,
+        userAddress: signer.address,
+        partner: referrer,
+      },
+      { ignoreChecks: true }
+    );
+
+    const transaction = {
+      ...txParams,
+      gasPrice: '0x' + new BigNumber(txParams.gasPrice).toString(16),
+      gasLimit: '0x' + new BigNumber(5000000).toString(16),
+      value: '0x' + new BigNumber(txParams.value).toString(16),
+    };
+    const toContract = new ethers.Contract(destToken, erc20abi, ethersProvider);
+    const beforeFromBalance = await ethersProvider.getBalance(signer.address);
+    const beforeToBalance = await toContract.balanceOf(signer.address);
+
+    const txr = await signer.sendTransaction(transaction);
+    await txr.wait(1);
+    const afterFromBalance = await ethersProvider.getBalance(signer.address);
+    const afterToBalance = await toContract.balanceOf(signer.address);
+    expect(beforeFromBalance.gt(afterFromBalance)).toBeTruthy();
+    expect(beforeToBalance.lt(afterToBalance)).toBeTruthy();
+  });
+  test('Build_and_Send_Tx_BUY', async () => {
+    const destAmount = srcAmount;
+    const priceRoute = await paraSwap.getRate({
+      srcToken,
+      destToken,
+      amount: destAmount,
+      userAddress: senderAddress,
+      side: SwapSide.BUY,
+      options: { includeDEXS: 'Uniswap,UniswapV2,Balancer,Oasis' },
+    });
+    const _srcAmount = new BigNumber(priceRoute.srcAmount)
+      .times(1.1)
+      .toFixed(0);
+
+    const txParams = await paraSwap.buildTx(
+      {
+        srcToken,
+        destToken,
+        srcAmount: _srcAmount,
+        destAmount,
+        priceRoute,
+        userAddress: signer.address,
+        partner: referrer,
+      },
+      { ignoreChecks: true }
+    );
+
+    const transaction = {
+      ...txParams,
+      gasPrice: '0x' + new BigNumber(txParams.gasPrice).toString(16),
+      gasLimit: '0x' + new BigNumber(5000000).toString(16),
+      value: '0x' + new BigNumber(txParams.value).toString(16),
+    };
+    const toContract = new ethers.Contract(destToken, erc20abi, ethersProvider);
+    const beforeFromBalance = await ethersProvider.getBalance(signer.address);
+    const beforeToBalance = await toContract.balanceOf(signer.address);
+
+    const txr = await signer.sendTransaction(transaction);
+    await txr.wait(1);
+    const afterFromBalance = await ethersProvider.getBalance(signer.address);
+    const afterToBalance = await toContract.balanceOf(signer.address);
+    expect(beforeFromBalance.gt(afterFromBalance)).toBeTruthy();
+    expect(beforeToBalance.lt(afterToBalance)).toBeTruthy();
+  });
+});
+
+describe.each([
+  [
+    'fetch & ethers',
+    { fetch },
+    {
+      ethersProviderOrSigner: signer,
+      EthersContract: ethers.Contract,
+      account: senderAddress,
+    },
+  ],
+  ['axios & web3', { axios }, { web3: web3provider, account: senderAddress }],
+])(
+  'ParaSwap SDK: contract calling methods: %s',
+  (testName, fetcherOptions, providerOptions) => {
+    let paraSwap: AllSDKMethods<TxHash>;
+
+    beforeAll(() => {
+      paraSwap = constructSimpleSDK(
+        { network, ...fetcherOptions },
+        providerOptions
+      );
+    });
+    test('approveToken', async () => {
+      const txHash = await paraSwap.approveToken('12345', DAI);
+
+      await ethersProvider.waitForTransaction(txHash);
+
+      const toContract = new ethers.Contract(
+        destToken,
+        erc20abi,
+        ethersProvider
+      );
+      const spender = await paraSwap.getSpender();
+      const allowance: BigNumberEthers = await toContract.allowance(
+        signer.address,
+        spender
+      );
+      expect(allowance.toString()).toEqual('12345');
+    });
+  }
+);


### PR DESCRIPTION
- Shuffled code around, so that every little file isn't directly in `src/*` and to make future functionality extensions easier
- Added `constructSimpleSDK`, which enables can provide API methods with minimal config.