### PR TITLE
Fix/nft and lo tests

### DIFF
--- a/tests/__snapshots__/limitOrders.test.ts.snap
+++ b/tests/__snapshots__/limitOrders.test.ts.snap
@@ -70,7 +70,7 @@ Object {
 exports[`Limit Orders buildLimitOrder p2p: P2P_Order_Data_Snapshot 1`] = `
 Object {
   "data": Object {
-    "expiry": 1671494400,
+    "expiry": 1766188800,
     "maker": "0xaC39b311DCEb2A4b2f5d8461c1cdaF756F4F7Ae9",
     "makerAmount": "1000000000000000000",
     "makerAsset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
@@ -127,7 +127,7 @@ Object {
 exports[`Limit Orders buildLimitOrder: Order_Data_Snapshot 1`] = `
 Object {
   "data": Object {
-    "expiry": 1671494400,
+    "expiry": 1766188800,
     "maker": "0xaC39b311DCEb2A4b2f5d8461c1cdaF756F4F7Ae9",
     "makerAmount": "1000000000000000000",
     "makerAsset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",

--- a/tests/__snapshots__/nftOrders.test.ts.snap
+++ b/tests/__snapshots__/nftOrders.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`NFT Orders buildNFTOrder p2p: P2P_Order_Data_Snapshot 1`] = `
 Object {
   "data": Object {
-    "expiry": 1671494400,
+    "expiry": 1766188800,
     "maker": "0xaC39b311DCEb2A4b2f5d8461c1cdaF756F4F7Ae9",
     "makerAmount": "1000000000000000000",
     "makerAsset": "2072883924162524385437572631638126955675586600207",
@@ -70,7 +70,7 @@ Object {
 exports[`NFT Orders buildNFTOrder: Order_Data_Snapshot 1`] = `
 Object {
   "data": Object {
-    "expiry": 1671494400,
+    "expiry": 1766188800,
     "maker": "0xaC39b311DCEb2A4b2f5d8461c1cdaF756F4F7Ae9",
     "makerAmount": "1000000000000000000",
     "makerAsset": "2072883924162524385437572631638126955675586600207",

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -18,7 +18,7 @@ type BuyErc20TokenForEthInput = {
   tokenAddress: string;
   signer: ethers.Wallet;
   chainId: number;
-  ethersProvider: ethers.providers.Web3Provider;
+  ethersProvider: ethers.providers.JsonRpcProvider;
 };
 
 type BuyErc20TokenForEthReturn = {

--- a/tests/limitOrders.test.ts
+++ b/tests/limitOrders.test.ts
@@ -282,7 +282,7 @@ describe('Limit Orders', () => {
 
   let orderInput: BuildLimitOrderInput;
   //                                        UTC format
-  const orderExpiry = Math.floor(new Date('2022-12-20').getTime() / 1000);
+  const orderExpiry = Math.floor(new Date('2025-12-20').getTime() / 1000);
 
   let AugustusRFQ: Contract;
 
@@ -1020,7 +1020,7 @@ describe('Limit Orders', () => {
 
         const signature = await sdk.signLimitOrder(signableOrderData);
         expect(signature).toMatchInlineSnapshot(
-          `"0x16349ef688849bfa4f75ae693e91e862de7e7f60a1038e832008e010db921adb2795df50ea898401663d5355077592ae7ad964e9b04aca58575eec645f3718691b"`
+          `"0x18b022691daab1d8a3486aab5a006f2e98932b1c2fe4f04726c766e7a4e6d4935cbbf6d03ef945f23bef5cf4e250086f14581b1b8097f6c3ffd62653c8b2454b1b"`
         );
 
         const presumedOrderHash = calculateOrderHash(signableOrderData);

--- a/tests/limitOrders.test.ts
+++ b/tests/limitOrders.test.ts
@@ -608,7 +608,7 @@ describe('Limit Orders', () => {
           partner: referrer,
           orders: [orderWithSignature],
         },
-        // @TODO remove ignoreChecks, currently ropsten balance is fetched wrong in api
+        // ignore checks as otherwise would throw "not enough BAT balance"
         { ignoreChecks: true }
       );
 

--- a/tests/limitOrders.test.ts
+++ b/tests/limitOrders.test.ts
@@ -284,9 +284,6 @@ describe('Limit Orders', () => {
   //                                        UTC format
   const orderExpiry = Math.floor(new Date('2022-12-20').getTime() / 1000);
 
-  let erc20Token1: Contract;
-  let erc20Token2: Contract;
-
   let AugustusRFQ: Contract;
 
   // let initialChainId2verifyingContract = { ...chainId2verifyingContract };
@@ -301,23 +298,6 @@ describe('Limit Orders', () => {
       takerAmount: (8e18).toString(10),
       maker: senderAddress,
     };
-
-    erc20Token1 = await ERC20MintableFactory.deploy(
-      'ERC20Token1',
-      'ERC20Token1'
-    );
-    await erc20Token1.deployTransaction.wait();
-
-    erc20Token2 = await ERC20MintableFactory.deploy(
-      'ERC20Token2',
-      'ERC20Token2'
-    );
-    await erc20Token2.deployTransaction.wait();
-
-    await erc20Token1.mint(walletStable.address, (60e18).toString(10));
-    await erc20Token1.mint(walletStable2.address, (60e18).toString(10));
-    await erc20Token2.mint(walletStable.address, (60e18).toString(10));
-    await erc20Token2.mint(walletStable2.address, (60e18).toString(10));
 
     paraSwap = constructPartialSDK<
       SDKConfig<ethers.ContractTransaction>,
@@ -572,8 +552,8 @@ describe('Limit Orders', () => {
 
     const signature = await makerSDK.signLimitOrder(signableOrderData);
 
-    const WETH_Token = erc20Token1.attach(WETH);
-    const BAT_Token = erc20Token1.attach(BAT);
+    const WETH_Token = ERC20MintableFactory.attach(WETH);
+    const BAT_Token = ERC20MintableFactory.attach(BAT);
 
     const makerToken1InitBalance: BigNumberEthers = await WETH_Token.balanceOf(
       maker.address
@@ -786,9 +766,9 @@ describe('Limit Orders', () => {
 
     const signature = await makerSDK.signLimitOrder(signableOrderData);
 
-    const WETH_Token = erc20Token1.attach(WETH);
-    const BAT_Token = erc20Token1.attach(BAT);
-    const DAI_Token = erc20Token1.attach(DAI);
+    const WETH_Token = ERC20MintableFactory.attach(WETH);
+    const BAT_Token = ERC20MintableFactory.attach(BAT);
+    const DAI_Token = ERC20MintableFactory.attach(DAI);
 
     const makerToken1InitBalance: BigNumberEthers = await WETH_Token.balanceOf(
       maker.address

--- a/tests/limitOrders.test.ts
+++ b/tests/limitOrders.test.ts
@@ -77,7 +77,9 @@ const destToken = HEX;
 
 const TEST_MNEMONIC =
   'radar blur cabbage chef fix engine embark joy scheme fiction master release';
+//0xaC39b311DCEb2A4b2f5d8461c1cdaF756F4F7Ae9
 const walletStable = ethers.Wallet.fromMnemonic(TEST_MNEMONIC);
+//0xD7c0Cd9e7d2701c710D64Fc492C7086679BdF7b4
 const walletStable2 = ethers.Wallet.fromMnemonic(
   TEST_MNEMONIC,
   "m/44'/60'/0'/0/1"
@@ -98,10 +100,11 @@ const ganacheProvider = ganache.provider({
   },
   quiet: true,
 });
-
-const ethersProvider = new ethers.providers.Web3Provider(
-  ganacheProvider as any
-);
+// if test against tenderly fork, make sure accounts have enough ETH and zero nonce
+const tenderlyForkUrl = process.env.TENDERLY_FORK_URL;
+const ethersProvider = tenderlyForkUrl
+  ? new ethers.providers.JsonRpcProvider(tenderlyForkUrl)
+  : new ethers.providers.Web3Provider(ganacheProvider as any);
 
 const signer = walletStable.connect(ethersProvider);
 const senderAddress = signer.address;

--- a/tests/nftOrders.test.ts
+++ b/tests/nftOrders.test.ts
@@ -296,7 +296,7 @@ describe('NFT Orders', () => {
 
   let orderInput: BuildNFTOrderInput;
   //                                        UTC format
-  const orderExpiry = Math.floor(new Date('2022-12-20').getTime() / 1000);
+  const orderExpiry = Math.floor(new Date('2025-12-20').getTime() / 1000);
 
   let erc20Token1: Contract;
   let erc20Token2: Contract;
@@ -731,7 +731,7 @@ describe('NFT Orders', () => {
 
     expect(orderWithSignature).toMatchInlineSnapshot(`
       Object {
-        "expiry": 1671494400,
+        "expiry": 1766188800,
         "maker": "0xaC39b311DCEb2A4b2f5d8461c1cdaF756F4F7Ae9",
         "makerAmount": "1",
         "makerAsset": "4315429714524158815340545734471553671933189254538",
@@ -739,7 +739,7 @@ describe('NFT Orders', () => {
         "makerAssetType": 2,
         "nonce": 999,
         "nonceAndMeta": "1461271868364326844682297910593670628577722568144820",
-        "signature": "0x7b097c5d5d07257bbe3c8cc0cfebbd7b178b954ba516da00218a9c383cfc20990ad42c9347a78a3e5984a18bdd0723ce21e91bccce2185da423c8bf1c86d0b6c1c",
+        "signature": "0x9360585f74eee3de2a12f6dc8c084b3c2646eaf62c3f1c829352bc2eb1e278d2542d36652fe864e3e717f26ed4b6c59554ba1b162ca5ed59a7b5bb32792409281b",
         "taker": "0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57",
         "takerAmount": "6000000000000000000",
         "takerAsset": "1096451400262405796991039590211805051831004063880",
@@ -1077,6 +1077,7 @@ describe('NFT Orders', () => {
       srcUSD: '---',
       destUSD: '---',
       gasCostUSD: '---',
+      gasCost: '---', // unstable, varies based on whether it's UniswapV2 or UniswapV3 at the time of writing
       bestRoute: priceRoute.bestRoute.map((route) => ({
         ...route,
         swaps: route.swaps.map((swap) => ({
@@ -1087,8 +1088,12 @@ describe('NFT Orders', () => {
               ...exchange.data,
               path: '---', // stablilze test because of variable path. Details: https://github.com/paraswap/paraswap-sdk/actions/runs/3218112679/jobs/5261882711#step:6:29
               pools: '---',
+              factory: '---',
+              feeFactor: '---',
+              initCode: '---',
               gasUSD: '---',
             },
+            exchange: '---', // unstable, sometimes it's UniswapV2, other times UniswapV3
             poolAddresses: ['---'],
             srcAmount: '---', //will change based on srcToken/destToken rate
           })),
@@ -1111,12 +1116,15 @@ describe('NFT Orders', () => {
                 "swapExchanges": Array [
                   Object {
                     "data": Object {
+                      "factory": "---",
+                      "feeFactor": "---",
                       "gasUSD": "---",
+                      "initCode": "---",
                       "path": "---",
                       "pools": "---",
                     },
                     "destAmount": "6000000000000000000",
-                    "exchange": "UniswapV3",
+                    "exchange": "---",
                     "percent": 100,
                     "poolAddresses": Array [
                       "---",
@@ -1135,7 +1143,7 @@ describe('NFT Orders', () => {
         "destDecimals": 18,
         "destToken": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
         "destUSD": "---",
-        "gasCost": "154300",
+        "gasCost": "---",
         "gasCostUSD": "---",
         "hmac": "---",
         "maxImpactReached": false,
@@ -1222,7 +1230,7 @@ describe('NFT Orders', () => {
 
         const signature = await sdk.signNFTOrder(signableOrderData);
         expect(signature).toMatchInlineSnapshot(
-          `"0x5f357e11807e9f5db61d16b245b060cc1e7fde8074f44e67cdeff2da04d78b522d45cccf124613ceb17948b1d8b75ef76c3b8edaa620d75d9f0ecab1cb0a07041b"`
+          `"0x72143ce3bc801dac394838d88d3acd39afce1999dee0ffff11bc4c69b5a2d76c02862144eb45a0f6033a3b04f5174c4eb0dbc2ebf0daa2af52528ed1ca12ae281b"`
         );
 
         const presumedOrderHash = calculateOrderHash(signableOrderData);

--- a/tests/nftOrders.test.ts
+++ b/tests/nftOrders.test.ts
@@ -756,7 +756,7 @@ describe('NFT Orders', () => {
           partner: referrer,
           orders: [orderWithSignature],
         },
-        // @TODO remove ignoreChecks, currently ropsten balance is fetched wrong in api
+        // ignore checks as otherwise would throw "not enough balance"
         { ignoreChecks: true }
       );
 

--- a/tests/nftOrders.test.ts
+++ b/tests/nftOrders.test.ts
@@ -82,7 +82,10 @@ const destToken = BUSD;
 
 const TEST_MNEMONIC =
   'radar blur cabbage chef fix engine embark joy scheme fiction master release';
+
+//0xaC39b311DCEb2A4b2f5d8461c1cdaF756F4F7Ae9
 const walletStable = ethers.Wallet.fromMnemonic(TEST_MNEMONIC);
+//0xD7c0Cd9e7d2701c710D64Fc492C7086679BdF7b4
 const walletStable2 = ethers.Wallet.fromMnemonic(
   TEST_MNEMONIC,
   "m/44'/60'/0'/0/1"
@@ -110,9 +113,11 @@ const ganacheProvider = ganache.provider({
   quiet: true,
 });
 
-const ethersProvider = new ethers.providers.Web3Provider(
-  ganacheProvider as any
-);
+// if test against tenderly fork, make sure accounts have enough ETH and zero nonce
+const tenderlyForkUrl = process.env.TENDERLY_FORK_URL;
+const ethersProvider = tenderlyForkUrl
+  ? new ethers.providers.JsonRpcProvider(tenderlyForkUrl)
+  : new ethers.providers.Web3Provider(ganacheProvider as any);
 
 const signer = walletStable.connect(ethersProvider);
 const senderAddress = signer.address;


### PR DESCRIPTION
Fixes erroring LO and NFT tests

The reason was expiry date being in the past, but it was obscured, since TX receipt doesn't contain any details or traces that'd give a hint _why_ it's failing.  So I had to eventually trace with tenderly and decided to adjust tests code to make it easier to test against tenderly fork next time

There's was also some instability in snapshot (route going through UniswapV2 or UniswapV3, which was effecting gasCost)