### PR TITLE
Transactions. ignoreAllowance param

### DIFF
--- a/src/methods/swap/transaction.ts
+++ b/src/methods/swap/transaction.ts
@@ -151,7 +151,6 @@ export type BuildOptionsBase = {
   ignoreAllowance?: boolean;
   /** @description Allows the API to return the contract parameters only. */
   onlyParams?: boolean;
-  simple?: boolean;
 };
 
 export type BuildOptionsWithGasPrice = BuildOptionsBase & Partial<WithGasPrice>;

--- a/src/methods/swap/transaction.ts
+++ b/src/methods/swap/transaction.ts
@@ -143,9 +143,13 @@ export type BuildTxInput =
   | BuildSwapAndNFTOrderTxInput;
 
 export type BuildOptionsBase = {
+  /** @description Allows the API to skip performing onchain checks such as balances, allowances, as well as transaction simulations. The response does not contain `gas` parameter when set to `true` */
   ignoreChecks?: boolean;
+  /** @description Allows the API to skip gas checks. The response does not contain `gas` parameter when set to `true` */
   ignoreGasEstimate?: boolean;
+  /** @description Allows the API to skip performing onchain allowance checks. */
   ignoreAllowance?: boolean;
+  /** @description Allows the API to return the contract parameters only. */
   onlyParams?: boolean;
   simple?: boolean;
 };

--- a/src/methods/swap/transaction.ts
+++ b/src/methods/swap/transaction.ts
@@ -145,6 +145,7 @@ export type BuildTxInput =
 export type BuildOptionsBase = {
   ignoreChecks?: boolean;
   ignoreGasEstimate?: boolean;
+  ignoreAllowance?: boolean;
   onlyParams?: boolean;
   simple?: boolean;
 };


### PR DESCRIPTION
`ignoreAllowance` parameter that is used in /transactions endpoint