### PR TITLE
SDK tokens interface response result error handling

### DIFF
--- a/src/methods/swap/token.ts
+++ b/src/methods/swap/token.ts
@@ -26,7 +26,7 @@ export const constructGetTokens = ({
       signal,
     });
 
-    const tokens = data.tokens.map(constructToken);
+    const tokens = data.data.tokens.map(constructToken);
     return tokens;
   };
 


### PR DESCRIPTION
SDK tokens interface response result error handling
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'map')
