### PR TITLE
Fix/compacting signatures

### DIFF
--- a/src/methods/delta/signDeltaOrder.ts
+++ b/src/methods/delta/signDeltaOrder.ts
@@ -1,4 +1,4 @@
-import { deriveCompactSignature } from '../../helpers/misc';
+// import { deriveCompactSignature } from '../../helpers/misc';
 import type { ConstructProviderFetchInput } from '../../types';
 import { SignableDeltaOrderData } from './helpers/buildDeltaOrderData';
 import { sanitizeDeltaOrderData } from './helpers/misc';
@@ -35,19 +35,24 @@ export const constructSignDeltaOrder = (
       typedDataOnly
     );
 
-    if (signature.length > 132) {
-      // signature more than 65 bytes, likely a multisig
-      // not compatible with EIP-2098 Compact Signatures
-      return signature;
-    }
+    // Safe signature with only one signer has length 132
+    // but if it is compacted, the recovered address doesn't match the signer
 
-    // both full and compact signatures work in the ParaswapDelta contract;
-    // compact signature can be marginally more gas efficient
-    try {
-      return deriveCompactSignature(signature);
-    } catch {
-      return signature;
-    }
+    return signature;
+
+    // if (signature.length > 132) {
+    //   // signature more than 65 bytes, likely a multisig
+    //   // not compatible with EIP-2098 Compact Signatures
+    //   return signature;
+    // }
+
+    // // both full and compact signatures work in the ParaswapDelta contract;
+    // // compact signature can be marginally more gas efficient
+    // try {
+    //   return deriveCompactSignature(signature);
+    // } catch {
+    //   return signature;
+    // }
   };
 
   return { signDeltaOrder };

--- a/tests/__snapshots__/quote.test.ts.snap
+++ b/tests/__snapshots__/quote.test.ts.snap
@@ -27,7 +27,7 @@ exports[`Quote:methods Get Fallback Market Quote for all 2`] = `
   ],
   "blockNumber": "dynamic_number",
   "contractAddress": "0x6a000f20005980200259b80c5102003040001068",
-  "contractMethod": "swapOnAugustusRFQTryBatchFill",
+  "contractMethod": "swapExactAmountIn",
   "destAmount": "dynamic_number",
   "destDecimals": 18,
   "destToken": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",


### PR DESCRIPTION
Edge case of a Safe Wallet with one signer only.
Signature ends up looking like a common EOA signature (132 length)
Compacting it messes up the signarue and it fails Safe.isValidSignature check

For now disable compacting.