### PR TITLE
chore: remove redundant explicit type annotations in constructFullSDK

### DIFF
--- a/src/sdk/full.ts
+++ b/src/sdk/full.ts
@@ -34,13 +34,10 @@ export const constructFullSDK = <TxResponse = any>(
   config: SDKConfig<TxResponse>
 ): AllSDKMethods<TxResponse> => {
   // include all available functions
-  const swap: SwapSDKMethods<TxResponse> = constructSwapSDK(config);
-  const limitOrders: LimitOrderHandlers<TxResponse> =
-    constructAllLimitOrdersHandlers(config);
-  const nftOrders: NFTOrderHandlers<TxResponse> =
-    constructAllNFTOrdersHandlers(config);
-  const delta: DeltaOrderHandlers<TxResponse> =
-    constructAllDeltaOrdersHandlers(config);
+  const swap = constructSwapSDK(config);
+  const limitOrders = constructAllLimitOrdersHandlers(config);
+  const nftOrders = constructAllNFTOrdersHandlers(config);
+  const delta = constructAllDeltaOrdersHandlers(config);
   const quote = constructGetQuote(config);
 
   return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> TypeScript-only refactor that relies on type inference for `constructFullSDK` local variables; no runtime logic or API shape changes expected, but could slightly affect inferred types if constructor signatures change.
> 
> **Overview**
> Removes redundant explicit local type annotations in `constructFullSDK` (`src/sdk/full.ts`), letting TypeScript infer `swap`, `limitOrders`, `nftOrders`, and `delta` types from their constructor functions.
> 
> No runtime behavior or returned object structure is changed; this is a small maintainability/typing cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f5ecc1d87b7b4eb84d697749075857dc08ea5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->