### PR TITLE
resolvePartnerFee/allow `deltaPrice.partnerFee=0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/methods/delta/helpers/misc.ts
+++ b/src/methods/delta/helpers/misc.ts
@@ -87,7 +87,7 @@ export async function resolvePartnerFee(
   let partnerAddress = options.partnerAddress;
   let partnerFeeBps =
     options.partnerFeeBps ??
-    (options.deltaPrice.partnerFee
+    (options.deltaPrice.partnerFee !== undefined
       ? options.deltaPrice.partnerFee * 100
       : undefined);
   let partnerTakesSurplus = options.partnerTakesSurplus;
@@ -117,7 +117,7 @@ export async function resolvePartnerFee(
   }
 
   return {
-    partnerAddress: partnerAddress!,
+    partnerAddress,
     partnerFeeBps: partnerFeeBps ?? 0,
     partnerTakesSurplus: partnerTakesSurplus ?? false,
   };


### PR DESCRIPTION
Allow to pass `deltaPrice.partnerFee: 0` to buildDeltaOrder, otherwise partnerFee is taken from /prices/partnerfee

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logic tweak in partner-fee resolution plus a version bump; main risk is unintended fallback/partner address handling for edge cases.
> 
> **Overview**
> Updates `resolvePartnerFee` to treat `deltaPrice.partnerFee = 0` as an explicitly supplied fee (instead of falling back to `/prices/partnerfee`), by checking `partnerFee !== undefined` rather than truthiness.
> 
> Also removes the non-null assertion on `partnerAddress` in the returned `ResolvedPartnerFee`, and bumps the SDK version to `9.5.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1815375c48c88e1517634d429e1ed5aa07556cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->