### PR TITLE
Chore/unified amounts min

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "9.5.3",
+  "version": "9.5.4",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/methods/delta/helpers/orders.ts
+++ b/src/methods/delta/helpers/orders.ts
@@ -283,7 +283,7 @@ function getUnifiedDeltaOrderData(
   const { order, chainId } = auction;
 
   const { srcToken, destToken } = getOrderTokenAddresses(order);
-  const { expected, final } = getAuctionAmounts(auction);
+  const { expected, final, minimal } = getAuctionAmounts(auction);
 
   const srcChainId = chainId;
   const destChainId = getAuctionDestChainId({ order, chainId });
@@ -300,6 +300,7 @@ function getUnifiedDeltaOrderData(
     amounts: {
       expected,
       final,
+      minimal,
     },
     srcToken,
     destToken,
@@ -362,6 +363,11 @@ function getAuctionAmounts(auction: DeltaAuction) {
     destAmount: auction.order.expectedAmount || auction.order.destAmount,
   };
 
+  let minimal = {
+    srcAmount: auction.order.srcAmount,
+    destAmount: auction.order.destAmount,
+  }
+
   const order = auction.order;
 
   if (isOrderCrosschain(order)) {
@@ -369,6 +375,14 @@ function getAuctionAmounts(auction: DeltaAuction) {
       srcAmount: expected.srcAmount,
       destAmount: scaleByFactor(
         BigInt(expected.destAmount),
+        order.bridge.scalingFactor
+      ).toString(),
+    };
+
+    minimal = {
+      srcAmount: minimal.srcAmount,
+      destAmount: scaleByFactor(
+        BigInt(minimal.destAmount),
         order.bridge.scalingFactor
       ).toString(),
     };
@@ -380,10 +394,12 @@ function getAuctionAmounts(auction: DeltaAuction) {
     return {
       final,
       expected,
+      minimal,
     };
   }
   return {
     expected,
+    minimal,
   };
 }
 

--- a/src/methods/delta/helpers/orders.ts
+++ b/src/methods/delta/helpers/orders.ts
@@ -195,10 +195,12 @@ function getTwapAuctionAmounts(
     return {
       final,
       expected,
+      minimal: expected, // TWAP orders don't have more detailed amounts
     };
   }
   return {
     expected,
+    minimal: expected, // TWAP orders don't have more detailed amounts
   };
 }
 
@@ -461,12 +463,12 @@ const failedAuctionStatusesSet = new Set<DeltaAuctionStatus>(
 
 type FailedDeltaAuctionProps =
   | {
-      status: (typeof failedAuctionStatuses)[number];
-    }
+    status: (typeof failedAuctionStatuses)[number];
+  }
   | {
-      status: 'EXECUTED'; // srcChain tx succeeded
-      bridgeStatus: 'expired' | 'refunded'; // destChain tx failed or relayer didn't deliver
-    };
+    status: 'EXECUTED'; // srcChain tx succeeded
+    bridgeStatus: 'expired' | 'refunded'; // destChain tx failed or relayer didn't deliver
+  };
 
 /**
  * @description Checks whether an auction is failed on source or destination chain.
@@ -557,8 +559,8 @@ function getFilledPercent(
   const completeTransactions = !isOrderCrosschain(auction.order)
     ? auction.transactions
     : auction.transactions.filter(
-        (transaction) => transaction.bridgeStatus === 'filled'
-      );
+      (transaction) => transaction.bridgeStatus === 'filled'
+    );
 
   const filledPercentBps = completeTransactions.reduce(
     (acc, { filledPercent }) => {

--- a/src/methods/delta/helpers/orders.ts
+++ b/src/methods/delta/helpers/orders.ts
@@ -368,7 +368,7 @@ function getAuctionAmounts(auction: DeltaAuction) {
   let minimal = {
     srcAmount: auction.order.srcAmount,
     destAmount: auction.order.destAmount,
-  }
+  };
 
   const order = auction.order;
 
@@ -463,12 +463,12 @@ const failedAuctionStatusesSet = new Set<DeltaAuctionStatus>(
 
 type FailedDeltaAuctionProps =
   | {
-    status: (typeof failedAuctionStatuses)[number];
-  }
+      status: (typeof failedAuctionStatuses)[number];
+    }
   | {
-    status: 'EXECUTED'; // srcChain tx succeeded
-    bridgeStatus: 'expired' | 'refunded'; // destChain tx failed or relayer didn't deliver
-  };
+      status: 'EXECUTED'; // srcChain tx succeeded
+      bridgeStatus: 'expired' | 'refunded'; // destChain tx failed or relayer didn't deliver
+    };
 
 /**
  * @description Checks whether an auction is failed on source or destination chain.
@@ -559,8 +559,8 @@ function getFilledPercent(
   const completeTransactions = !isOrderCrosschain(auction.order)
     ? auction.transactions
     : auction.transactions.filter(
-      (transaction) => transaction.bridgeStatus === 'filled'
-    );
+        (transaction) => transaction.bridgeStatus === 'filled'
+      );
 
   const filledPercentBps = completeTransactions.reduce(
     (acc, { filledPercent }) => {

--- a/src/methods/delta/helpers/types.ts
+++ b/src/methods/delta/helpers/types.ts
@@ -257,13 +257,13 @@ type DeltaAuctionBase = {
 
 export type DeltaAuction<T extends OnChainOrderType = OnChainOrderType> =
   T extends T
-  ? Prettify<
-    DeltaAuctionBase & {
-      onChainOrderType: T;
-      order: OnChainOrderMap[T];
-    } & BridgeAuctionFiledsMap[T]
-  >
-  : never;
+    ? Prettify<
+        DeltaAuctionBase & {
+          onChainOrderType: T;
+          order: OnChainOrderMap[T];
+        } & BridgeAuctionFiledsMap[T]
+      >
+    : never;
 
 export type DeltaAuctionDelta = DeltaAuction<'Order'>;
 export type DeltaAuctionExternal = DeltaAuction<'ExternalOrder'>;

--- a/src/methods/delta/helpers/types.ts
+++ b/src/methods/delta/helpers/types.ts
@@ -257,13 +257,13 @@ type DeltaAuctionBase = {
 
 export type DeltaAuction<T extends OnChainOrderType = OnChainOrderType> =
   T extends T
-    ? Prettify<
-        DeltaAuctionBase & {
-          onChainOrderType: T;
-          order: OnChainOrderMap[T];
-        } & BridgeAuctionFiledsMap[T]
-      >
-    : never;
+  ? Prettify<
+    DeltaAuctionBase & {
+      onChainOrderType: T;
+      order: OnChainOrderMap[T];
+    } & BridgeAuctionFiledsMap[T]
+  >
+  : never;
 
 export type DeltaAuctionDelta = DeltaAuction<'Order'>;
 export type DeltaAuctionExternal = DeltaAuction<'ExternalOrder'>;
@@ -330,7 +330,12 @@ export type UnifiedDeltaOrderData = {
       srcAmount: string;
       destAmount: string;
     };
-    /** @description  final amounts after Order execution. May be less than expected if there is slippage  or only partial execution was achieved */
+    /** @description  minimal amounts that user should receive if the order is filled, known at the start of Order execution */
+    minimal: {
+      srcAmount: string;
+      destAmount: string;
+    };
+    /** @description  final amounts after Order execution. May be less than expected if there is slippage or only partial execution was achieved */
     final?: {
       srcAmount: string;
       destAmount: string;


### PR DESCRIPTION
Adding minimal amounts to unified OrderData

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public type and helper output with no auth or execution-path changes; consumers only need to handle the new required `minimal` field if they construct the type manually.
> 
> **Overview**
> **Unified delta order data** now exposes a required **`amounts.minimal`** pair (src/dest) alongside existing `expected` and optional `final`, so consumers can read the user’s floor amounts from the order at execution start.
> 
> For standard Delta/external auctions, **minimal** uses `order.srcAmount` and `order.destAmount` (not the `expectedAmount` fallback used for **expected** dest). **Cross-chain** orders apply the same bridge **scaling factor** to minimal dest as for expected. **TWAP** auctions set **minimal** equal to **expected** because slice-level mins aren’t modeled separately.
> 
> `UnifiedDeltaOrderData` types and `getUnifiedDeltaOrderData` / `getAuctionAmounts` / `getTwapAuctionAmounts` are updated accordingly; package version is **9.5.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a4b7f9bbcaf06a69edfe3bca3f9624337e2d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->