### PR TITLE
Chore/change default API_URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,5 +12,5 @@ export {
 // allows to pass by name instead of importing enum first
 export type ContractMethodByName = EnumerateLiteral<typeof ContractMethod>;
 
-export const API_URL = 'https://api.paraswap.io';
+export const API_URL = 'https://api.velora.xyz';
 export const DEFAULT_VERSION = '6.2' satisfies APIVersion;

--- a/src/methods/swap/rates.ts
+++ b/src/methods/swap/rates.ts
@@ -52,7 +52,7 @@ type RateQueryParams = {
   otherExchangePrices?: boolean;
 
   /**
-   * @description Comma Separated List of DEXs to include. **Supported DEXs:** UniswapV2, UniswapV3, Kyber, Bancor, AugustusRFQ, Oasis, Compound, Fulcrum, Balancer, MakerDAO, Chai, Aave, Aave2 and more. You can view all currently supported dexes filtered by chain [here](https://api.paraswap.io/adapters/list/1) eg: `UniswapV3,MakerDAO`.
+   * @description Comma Separated List of DEXs to include. **Supported DEXs:** UniswapV2, UniswapV3, Kyber, Bancor, AugustusRFQ, Oasis, Compound, Fulcrum, Balancer, MakerDAO, Chai, Aave, Aave2 and more. You can view all currently supported dexes filtered by chain [here](https://api.velora.xyz/adapters/list/1) eg: `UniswapV3,MakerDAO`.
    */
   includeDEXS?: string;
 


### PR DESCRIPTION
part of FRNT-1351

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default API base URL affects all default SDK HTTP traffic; callers depending on the ParaSwap host must override `apiURL` or upgrade intentionally.
> 
> **Overview**
> **Switches the SDK’s default market API host** from `https://api.paraswap.io` to `https://api.velora.xyz` via `API_URL` in `constants.ts`. Integrations that do not pass a custom `apiURL` will now call Velora’s endpoint for rates, swaps, delta, and other constructed fetchers.
> 
> Bumps package version **10.0.0 → 10.0.1** and updates the `includeDEXS` JSDoc link in `rates.ts` to the new adapters list URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53b4ae18f45a5a079bb9d10f30ede7cd39c33545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->