### PR TITLE
Feat/delta buildCancelDeltaOrder util

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Submit orchestrators (`constructSubmitDeltaOrder`, `constructSubmitExternalDelta
 | `postDeltaOrder.ts` / `postExternalDeltaOrder.ts` / `postTWAPDeltaOrder.ts` | `constructPostDeltaOrder` | POST `/v2/delta/orders` → `DeltaAuction` | No |
 | `getDeltaPrice.ts` | `constructGetDeltaPrice` | GET `/v2/delta/prices` → `DeltaPrice` (route-based: `route` + `alternatives`; cross-chain handled in-route via `destChainId`) | No |
 | `getDeltaOrders.ts` | `constructGetDeltaOrders` | `getDeltaOrders` (paginated list), `getDeltaOrderById`, `getDeltaOrderByHash`, `getRequiredBalanceForDeltaOrders`. Reads return `DeltaAuction`. | No |
-| `cancelDeltaOrder.ts` | `constructCancelDeltaOrder` | `signCancelDeltaOrderRequest` → `postCancelDeltaOrderRequest` → `cancelDeltaOrders` (orchestrator). POST `/v2/orders/cancel`. | No (`any`) |
+| `cancelDeltaOrder.ts` | `constructCancelDeltaOrder` | `buildCancelDeltaOrder` (EIP-712 signable data, via `buildCancelDeltaOrderSignableData`) → `signCancelDeltaOrderRequest` → `postCancelDeltaOrderRequest` → `cancelDeltaOrders` (orchestrator). POST `/v2/orders/cancel`. | No (`any`) |
 | `getBridgeRoutes.ts` | `constructGetBridgeRoutes` | `getBridgeRoutes` (flat `BridgeRoute[]`) + `getBridgeProtocols` | No |
 | `isTokenSupportedInDelta.ts` | `constructIsTokenSupportedInDelta` | GET `/v2/delta/prices/is-token-supported` → `boolean` | No |
 | `getAgentsList.ts` | `constructGetAgentsList` | GET `/v2/agents/list/:chainId` → `string[]` | No |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ npx tsc --noEmit    # type-check without emitting
 ```
 
 Run a single test file:
+
 ```bash
 pnpm test --testPathPattern=src/path/to/file.test.ts
 ```
@@ -25,11 +26,11 @@ pnpm test --testPathPattern=src/path/to/file.test.ts
 
 Three ways to construct the SDK:
 
-| File | Export | Use When |
-|------|--------|----------|
-| `simple.ts` | `constructSimpleSDK(options, providerOptions?)` | Most consumers — handles fetcher/provider wiring automatically |
-| `full.ts` | `constructFullSDK<TxResponse>(config)` | Full control over all methods, namespaced (`sdk.delta.*`, `sdk.swap.*`) |
-| `partial.ts` | `constructPartialSDK<Config, Funcs>(config, ...funcs)` | Pick only the constructors you need; TypeScript infers the return type |
+| File         | Export                                                 | Use When                                                                |
+| ------------ | ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `simple.ts`  | `constructSimpleSDK(options, providerOptions?)`        | Most consumers — handles fetcher/provider wiring automatically          |
+| `full.ts`    | `constructFullSDK<TxResponse>(config)`                 | Full control over all methods, namespaced (`sdk.delta.*`, `sdk.swap.*`) |
+| `partial.ts` | `constructPartialSDK<Config, Funcs>(config, ...funcs)` | Pick only the constructors you need; TypeScript infers the return type  |
 
 `constructSimpleSDK` accepts `{ axios }`, `{ fetch }`, or `{ fetcher }` for the network layer, and optionally `{ ethersProviderOrSigner | ethersV6ProviderOrSigner | viemClient | web3, account }` for signing/transacting.
 
@@ -38,6 +39,7 @@ Three ways to construct the SDK:
 ## Provider Adapters (`src/helpers/providers/`)
 
 Each file exports `constructContractCaller(provider, account)` → `ContractCallerFunctions<TxResponse>`:
+
 - `viem.ts` — viem `PublicClient` + `WalletClient` (`Hex` tx response)
 - `ethers.ts` — ethersv5 provider/signer (`ContractTransaction` tx response)
 - `ethersV6.ts` — ethersv6 provider/signer
@@ -54,6 +56,7 @@ Each file exports `constructContractCaller(provider, account)` → `ContractCall
 ## Composable Constructor Pattern
 
 Every feature module exports a `constructXxx(options) => XxxFunctions` factory:
+
 - `options` is `ConstructProviderFetchInput<T, D>` or a `Pick` of it
 - `D` selects required caller methods: `'transactCall'` | `'signTypedDataCall'` | both
 - Generic `<T>` = transaction response type (e.g., `TxHash`, `ethers.ContractTransaction`)
@@ -63,6 +66,7 @@ Every feature module exports a `constructXxx(options) => XxxFunctions` factory:
 ## Key Patterns
 
 ### On-Chain Transaction (reference: `src/methods/delta/preSignDeltaOrder.ts`)
+
 1. Define minimal ABI inline as `const XxxAbi = [...] as const`
 2. Extract method names: `type AvailableMethods = ExtractAbiMethodNames<typeof XxxAbi>`
 3. Constructor takes `ConstructProviderFetchInput<T, 'transactCall'>`
@@ -70,6 +74,7 @@ Every feature module exports a `constructXxx(options) => XxxFunctions` factory:
 5. Call contract: `options.contractCaller.transactCall<AvailableMethods>({ address, abi, contractMethod, args, overrides })`
 
 ### API Call (reference: `src/methods/delta/cancelDeltaOrder.ts` sign/post methods)
+
 1. Sign EIP-712 typed data via `options.contractCaller.signTypedDataCall(typedData)`
 2. POST to API via `options.fetcher<ResponseType>({ url, method, data })`
 
@@ -77,7 +82,7 @@ Every feature module exports a `constructXxx(options) => XxxFunctions` factory:
 
 Delta is the SDK's core feature: server-built, on-chain auction orders. Exposed as `sdk.delta.*` and via bare top-level exports.
 
-> **History.** Delta was once a **v1** with local EIP-712 order building and per-family sign functions. It was replaced (breaking) by the server-built **v2** described here — `sdk.delta.*` *is* v2, with a single set of bare top-level exports. All Delta URLs use the `/v2/delta/...` prefix.
+> **History.** Delta was once a **v1** with local EIP-712 order building and per-family sign functions. It was replaced (breaking) by the server-built **v2** described here — `sdk.delta.*` _is_ v2, with a single set of bare top-level exports. All Delta URLs use the `/v2/delta/...` prefix.
 
 Order building is **server-side**: `POST /v2/delta/orders/build` returns a `BuiltDeltaOrder { toSign, orderHash }`; a single `signDeltaOrder(builtOrder)` signs every family; `post*` submits the signed order. Partner fee is passed as raw params (`partner`, `partnerFeeBps`) to the server rather than resolved locally. Reads are paginated (`PaginatedResponse<DeltaAuction>`), price is route-based.
 
@@ -85,13 +90,13 @@ Order building is **server-side**: `POST /v2/delta/orders/build` returns a `Buil
 
 All built via `POST /v2/delta/orders/build` with an `orderType` field:
 
-| Family | `orderType` / `onChainOrderType` | Build params | Build fn |
-|--------|-------------------|-----------|----------|
-| Standard | `'Order'` | `BuildDeltaOrderParams` | `buildDeltaOrder` |
-| External | `'ExternalOrder'` | `BuildExternalDeltaOrderParams` (adds `handler`, `data`) | `buildExternalDeltaOrder` |
-| TWAP Sell | `'TWAPOrder'` | `BuildTWAPSellDeltaOrderParams` | `buildTWAPDeltaOrder` |
-| TWAP Buy | `'TWAPBuyOrder'` | `BuildTWAPBuyDeltaOrderParams` | `buildTWAPDeltaOrder` |
-| Productive | `'ProductiveOrder'` | _read-only_ — no SDK builder (server-produced) | — |
+| Family     | `orderType` / `onChainOrderType` | Build params                                             | Build fn                  |
+| ---------- | -------------------------------- | -------------------------------------------------------- | ------------------------- |
+| Standard   | `'Order'`                        | `BuildDeltaOrderParams`                                  | `buildDeltaOrder`         |
+| External   | `'ExternalOrder'`                | `BuildExternalDeltaOrderParams` (adds `handler`, `data`) | `buildExternalDeltaOrder` |
+| TWAP Sell  | `'TWAPOrder'`                    | `BuildTWAPSellDeltaOrderParams`                          | `buildTWAPDeltaOrder`     |
+| TWAP Buy   | `'TWAPBuyOrder'`                 | `BuildTWAPBuyDeltaOrderParams`                           | `buildTWAPDeltaOrder`     |
+| Productive | `'ProductiveOrder'`              | _read-only_ — no SDK builder (server-produced)           | —                         |
 
 `'FillableOrder'` is also a key in `OnChainOrderMap`/`OnChainOrderType`, mapping to the same `DeltaAuctionOrder` shape as `'Order'`. It is not a separate buildable family — it's the `onChainOrderType` the server reports when a Standard order is `partiallyFillable`. Only surfaces (read-only) on the way back through the read paths.
 
@@ -99,24 +104,24 @@ Submit orchestrators (`constructSubmitDeltaOrder`, `constructSubmitExternalDelta
 
 ### Key Files
 
-| File | Constructor | Purpose | Generic? |
-|------|-------------|---------|----------|
-| `index.ts` | `constructAllDeltaOrdersHandlers`, `constructSubmit{Delta,External,TWAP}Order`, `constructSignDeltaOrder` | Composite: orchestrates all modules, defines `DeltaOrderHandlers<T>`, hosts the single `signDeltaOrder` (signs any `BuiltDeltaOrder`), re-exports every leaf module | `allHandlers`: `<T>` |
-| `buildDeltaOrder.ts` | `constructBuildDeltaOrder` | POST `/v2/orders/build` → `BuiltDeltaOrder` | No |
-| `buildExternalDeltaOrder.ts` | `constructBuildExternalDeltaOrder` | Same, `orderType: 'ExternalOrder'` | No |
-| `buildTWAPDeltaOrder.ts` | `constructBuildTWAPDeltaOrder` | Same, `orderType: 'TWAPOrder'` / `'TWAPBuyOrder'` | No |
-| `postDeltaOrder.ts` / `postExternalDeltaOrder.ts` / `postTWAPDeltaOrder.ts` | `constructPostDeltaOrder` | POST `/v2/delta/orders` → `DeltaAuction` | No |
-| `getDeltaPrice.ts` | `constructGetDeltaPrice` | GET `/v2/delta/prices` → `DeltaPrice` (route-based: `route` + `alternatives`; cross-chain handled in-route via `destChainId`) | No |
-| `getDeltaOrders.ts` | `constructGetDeltaOrders` | `getDeltaOrders` (paginated list), `getDeltaOrderById`, `getDeltaOrderByHash`, `getRequiredBalanceForDeltaOrders`. Reads return `DeltaAuction`. | No |
-| `cancelDeltaOrder.ts` | `constructCancelDeltaOrder` | `buildCancelDeltaOrder` (EIP-712 signable data, via `buildCancelDeltaOrderSignableData`) → `signCancelDeltaOrderRequest` → `postCancelDeltaOrderRequest` → `cancelDeltaOrders` (orchestrator). POST `/v2/orders/cancel`. | No (`any`) |
-| `getBridgeRoutes.ts` | `constructGetBridgeRoutes` | `getBridgeRoutes` (flat `BridgeRoute[]`) + `getBridgeProtocols` | No |
-| `isTokenSupportedInDelta.ts` | `constructIsTokenSupportedInDelta` | GET `/v2/delta/prices/is-token-supported` → `boolean` | No |
-| `getAgentsList.ts` | `constructGetAgentsList` | GET `/v2/agents/list/:chainId` → `string[]` | No |
-| `getDeltaContract.ts` | `constructGetDeltaContract` | Resolve ParaswapDelta contract address | No |
-| `getPartnerFee.ts` | `constructGetPartnerFee` | Fetch partner fee info (cached per partner in a `Map`) | No |
-| `approveForDelta.ts` | `constructApproveTokenForDelta` | ERC-20 `approve` with ParaswapDelta as spender | `<T>` |
-| `preSignDeltaOrder.ts` / `preSignExternalDeltaOrder.ts` / `preSignTWAPDeltaOrder.ts` | `constructPreSign*DeltaOrder` | On-chain `setPreSignature` + order hashing helpers (`produceDeltaOrderHash`, etc.) | `<T>` |
-| `deltaTokenModule.ts` | `constructDeltaTokenModule` | On-chain `cancelAndWithdrawDeltaOrder`, `withdrawDeltaNative`, `depositNativeAndPreSign`, `depositNativeAndPreSignDeltaOrder` | `<T>` |
+| File                                                                                 | Constructor                                                                                               | Purpose                                                                                                                                                                                                                  | Generic?             |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| `index.ts`                                                                           | `constructAllDeltaOrdersHandlers`, `constructSubmit{Delta,External,TWAP}Order`, `constructSignDeltaOrder` | Composite: orchestrates all modules, defines `DeltaOrderHandlers<T>`, hosts the single `signDeltaOrder` (signs any `BuiltDeltaOrder`), re-exports every leaf module                                                      | `allHandlers`: `<T>` |
+| `buildDeltaOrder.ts`                                                                 | `constructBuildDeltaOrder`                                                                                | POST `/v2/orders/build` → `BuiltDeltaOrder`                                                                                                                                                                              | No                   |
+| `buildExternalDeltaOrder.ts`                                                         | `constructBuildExternalDeltaOrder`                                                                        | Same, `orderType: 'ExternalOrder'`                                                                                                                                                                                       | No                   |
+| `buildTWAPDeltaOrder.ts`                                                             | `constructBuildTWAPDeltaOrder`                                                                            | Same, `orderType: 'TWAPOrder'` / `'TWAPBuyOrder'`                                                                                                                                                                        | No                   |
+| `postDeltaOrder.ts` / `postExternalDeltaOrder.ts` / `postTWAPDeltaOrder.ts`          | `constructPostDeltaOrder`                                                                                 | POST `/v2/delta/orders` → `DeltaAuction`                                                                                                                                                                                 | No                   |
+| `getDeltaPrice.ts`                                                                   | `constructGetDeltaPrice`                                                                                  | GET `/v2/delta/prices` → `DeltaPrice` (route-based: `route` + `alternatives`; cross-chain handled in-route via `destChainId`)                                                                                            | No                   |
+| `getDeltaOrders.ts`                                                                  | `constructGetDeltaOrders`                                                                                 | `getDeltaOrders` (paginated list), `getDeltaOrderById`, `getDeltaOrderByHash`, `getRequiredBalanceForDeltaOrders`. Reads return `DeltaAuction`.                                                                          | No                   |
+| `cancelDeltaOrder.ts`                                                                | `constructCancelDeltaOrder`                                                                               | `buildCancelDeltaOrder` (EIP-712 signable data, via `buildCancelDeltaOrderSignableData`) → `signCancelDeltaOrderRequest` → `postCancelDeltaOrderRequest` → `cancelDeltaOrders` (orchestrator). POST `/v2/orders/cancel`. | No (`any`)           |
+| `getBridgeRoutes.ts`                                                                 | `constructGetBridgeRoutes`                                                                                | `getBridgeRoutes` (flat `BridgeRoute[]`) + `getBridgeProtocols`                                                                                                                                                          | No                   |
+| `isTokenSupportedInDelta.ts`                                                         | `constructIsTokenSupportedInDelta`                                                                        | GET `/v2/delta/prices/is-token-supported` → `boolean`                                                                                                                                                                    | No                   |
+| `getAgentsList.ts`                                                                   | `constructGetAgentsList`                                                                                  | GET `/v2/agents/list/:chainId` → `string[]`                                                                                                                                                                              | No                   |
+| `getDeltaContract.ts`                                                                | `constructGetDeltaContract`                                                                               | Resolve ParaswapDelta contract address                                                                                                                                                                                   | No                   |
+| `getPartnerFee.ts`                                                                   | `constructGetPartnerFee`                                                                                  | Fetch partner fee info (cached per partner in a `Map`)                                                                                                                                                                   | No                   |
+| `approveForDelta.ts`                                                                 | `constructApproveTokenForDelta`                                                                           | ERC-20 `approve` with ParaswapDelta as spender                                                                                                                                                                           | `<T>`                |
+| `preSignDeltaOrder.ts` / `preSignExternalDeltaOrder.ts` / `preSignTWAPDeltaOrder.ts` | `constructPreSign*DeltaOrder`                                                                             | On-chain `setPreSignature` + order hashing helpers (`produceDeltaOrderHash`, etc.)                                                                                                                                       | `<T>`                |
+| `deltaTokenModule.ts`                                                                | `constructDeltaTokenModule`                                                                               | On-chain `cancelAndWithdrawDeltaOrder`, `withdrawDeltaNative`, `depositNativeAndPreSign`, `depositNativeAndPreSignDeltaOrder`                                                                                            | `<T>`                |
 
 The on-chain modules (`preSign*`, `deltaTokenModule`, `approveForDelta`) and the local EIP-712 hashing helpers (`helpers/build*OrderData`, `helpers/misc`) are retained from the original delta module — they back the on-chain flows (pre-signing, native deposit, cancel-and-withdraw) that complement server-side building.
 
@@ -127,6 +132,7 @@ The on-chain modules (`preSign*`, `deltaTokenModule`, `approveForDelta`) and the
 - `PaginatedResponse<T>` lives in `src/types.ts`.
 
 ### Delta Helpers (`src/methods/delta/helpers/`)
+
 - `types.ts` — shared order-struct types (above).
 - `buildDeltaOrderData.ts` / `buildExternalOrderData.ts` / `buildTWAPOrderData.ts` — EIP-712 typed-data producers (`produceDeltaOrderTypedData` / `produceExternalOrderTypedData` / `produceTWAPOrderTypedData`) + the `SignableDeltaOrderData` / `SignableExternalOrderData` / `SignableTWAPOrderData` types. Consumed by `preSign*` / `deltaTokenModule` for on-chain hashing/pre-signing. (The v1 local order-struct builders and `DELTA_DEFAULT_EXPIRY` were dropped — the server builds the order now.)
 - `buildCancelDeltaOrderData.ts` — `SignableCancelDeltaOrderData`, `CancelDeltaOrderData`.
@@ -137,6 +143,7 @@ The on-chain modules (`preSign*`, `deltaTokenModule`, `approveForDelta`) and the
 - `abi.ts` — shared ABI fragments.
 
 ### Core Types (`src/`)
+
 - `types.ts` — `ConstructProviderFetchInput`, `ContractCallerFunctions`, `TxSendOverrides`, `PaginatedResponse<T>`
 - `helpers/misc.ts` — `ExtractAbiMethodNames<T>`
 - `sdk/partial.ts` — `constructPartialSDK`, `InferWithTxResponse` type tuple
@@ -196,6 +203,7 @@ OrderWithSig tuple:
 ```
 
 ## Key Conventions
+
 - Contract address is always resolved via `constructGetDeltaContract(options).getDeltaContract()`
 - EIP-712 domain: `{ name: 'Portikus', version: '2.0.0', chainId, verifyingContract }`
 - Order hash: computed via viem's `hashTypedData` in `produceDeltaOrderHash()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,16 @@ TypeScript SDK for the Paraswap/Velora Delta protocol (on-chain order-based DEX)
 ## Commands
 
 ```bash
-yarn build          # compile to dist/
-yarn test           # run Jest tests (testEnvironment: node)
-yarn lint           # dts lint
-yarn start          # watch mode (dts watch)
+pnpm build          # compile to dist/
+pnpm test           # run Jest tests (testEnvironment: node)
+pnpm lint           # dts lint
+pnpm start          # watch mode (dts watch)
 npx tsc --noEmit    # type-check without emitting
 ```
 
 Run a single test file:
 ```bash
-yarn test --testPathPattern=src/path/to/file.test.ts
+pnpm test --testPathPattern=src/path/to/file.test.ts
 ```
 
 ## SDK Entry Points (`src/sdk/`)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 Refer to the documentation of the Velora API: https://developers.velora.xyz/
 
 ## Features
+
 **Versatility**: works with [web3](https://www.npmjs.com/package/web3) or [ethers](https://www.npmjs.com/package/ethers) without a direct dependency — or with [viem](https://viem.sh/) (also used internally for its utils)
 
 **Canonical**: bring only the functions you actually need
@@ -60,102 +61,112 @@ You can see some examples in [/src/examples](src/examples) directory.
 Can be created by providing `chainId` and either `axios` or `window.fetch` (or alternative `fetch` implementation), and an optional `version` (`'5'` or `'6.2'`) parameter that corresponds to the API version SDK will be making requests to. The resulting SDK will be able to use all methods that query the API.
 
 ```ts
-  import { constructSimpleSDK } from '@velora-dex/sdk';
-  import axios from 'axios';
+import { constructSimpleSDK } from '@velora-dex/sdk';
+import axios from 'axios';
 
-  // construct minimal SDK with fetcher only
-  const minSDK = constructSimpleSDK({chainId: 1, axios});
-  // or
-  const minSDK = constructSimpleSDK({chainId: 1, fetch: window.fetch, version: '5'});
+// construct minimal SDK with fetcher only
+const minSDK = constructSimpleSDK({ chainId: 1, axios });
+// or
+const minSDK = constructSimpleSDK({
+  chainId: 1,
+  fetch: window.fetch,
+  version: '5',
+});
 
-  const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-  const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
 
-  async function swapExample() {
-    //                                     or any other signer/provider
-    const signer: JsonRpcSigner = ethers.Wallet.fromMnemonic('__your_mnemonic__');
-    const senderAddress = signer.address;
+async function swapExample() {
+  //                                     or any other signer/provider
+  const signer: JsonRpcSigner = ethers.Wallet.fromMnemonic('__your_mnemonic__');
+  const senderAddress = signer.address;
 
-    const priceRoute = await minSDK.swap.getRate({
-      srcToken: ETH,
-      destToken: DAI,
-      amount: srcAmount,
-      userAddress: senderAddress,
-      side: SwapSide.SELL,
-    });
+  const priceRoute = await minSDK.swap.getRate({
+    srcToken: ETH,
+    destToken: DAI,
+    amount: srcAmount,
+    userAddress: senderAddress,
+    side: SwapSide.SELL,
+  });
 
-    const txParams = await minSDK.swap.buildTx(
-      {
-        srcToken,
-        destToken,
-        srcAmount,
-        destAmount,
-        priceRoute,
-        userAddress: senderAddress,
-        partner: referrer,
-      }
-    );
+  const txParams = await minSDK.swap.buildTx({
+    srcToken,
+    destToken,
+    srcAmount,
+    destAmount,
+    priceRoute,
+    userAddress: senderAddress,
+    partner: referrer,
+  });
 
-    const transaction = {
-      ...txParams,
-      gasPrice: '0x' + new BigNumber(txParams.gasPrice).toString(16),
-      gasLimit: '0x' + new BigNumber(5000000).toString(16),
-      value: '0x' + new BigNumber(txParams.value).toString(16),
-    };
+  const transaction = {
+    ...txParams,
+    gasPrice: '0x' + new BigNumber(txParams.gasPrice).toString(16),
+    gasLimit: '0x' + new BigNumber(5000000).toString(16),
+    value: '0x' + new BigNumber(txParams.value).toString(16),
+  };
 
-    const txr = await signer.sendTransaction(transaction);
-  }
+  const txr = await signer.sendTransaction(transaction);
+}
 ```
 
 If optional `providerOptions` is provided as the second parameter, then the resulting SDK will also be able to approve Tokens for swap, sign Orders, etc.
 
 ```ts
-  // with ethers@5
-  const providerOptionsEtherV5 = {
-    ethersProviderOrSigner: provider, // JsonRpcProvider
-    EthersContract: ethers.Contract,
-    account: senderAddress,
-  };
+// with ethers@5
+const providerOptionsEtherV5 = {
+  ethersProviderOrSigner: provider, // JsonRpcProvider
+  EthersContract: ethers.Contract,
+  account: senderAddress,
+};
 
-  // with ethers@6
-  const providerOptionsEtherV6 = {
-    ethersV6ProviderOrSigner: provider, // JsonRpcProvider
-    EthersV6Contract: ethers.Contract,
-    account: senderAddress,
-  };
+// with ethers@6
+const providerOptionsEtherV6 = {
+  ethersV6ProviderOrSigner: provider, // JsonRpcProvider
+  EthersV6Contract: ethers.Contract,
+  account: senderAddress,
+};
 
-  // or with viem (from wagmi or standalone)
-    const providerOptionsViem = {
-    viemClient, // made with createWalletClient()
-    account: senderAddress,
-  };
+// or with viem (from wagmi or standalone)
+const providerOptionsViem = {
+  viemClient, // made with createWalletClient()
+  account: senderAddress,
+};
 
-  // or with web3.js
-  const providerOptionsWeb3 = {
-    web3, // new Web3(...) instance
-    account: senderAddress,
-  };
+// or with web3.js
+const providerOptionsWeb3 = {
+  web3, // new Web3(...) instance
+  account: senderAddress,
+};
 
-  const sdk = constructSimpleSDK({chainId: 1, axios}, providerOptionsEtherV5);
+const sdk = constructSimpleSDK({ chainId: 1, axios }, providerOptionsEtherV5);
 
-  // approve token through sdk
-  const txHash = await sdk.approveToken(amountInWei, DAI);
+// approve token through sdk
+const txHash = await sdk.approveToken(amountInWei, DAI);
 
-  // await tx somehow
-  await provider.waitForTransaction(txHash);
+// await tx somehow
+await provider.waitForTransaction(txHash);
 ```
 
 ### Full SDK
+
 ```typescript
-import { constructFullSDK, constructAxiosFetcher, constructEthersContractCaller } from '@velora-dex/sdk';
+import {
+  constructFullSDK,
+  constructAxiosFetcher,
+  constructEthersContractCaller,
+} from '@velora-dex/sdk';
 
 const signer = ethers.Wallet.fromMnmemonic('__your_mnemonic__'); // or any other signer/provider
 const account = '__signer_address__';
 
-const contractCaller = constructEthersContractCaller({
-  ethersProviderOrSigner: signer,
-  EthersContract: ethers.Contract,
-}, account); // alternatively constructViemContractCaller or constructWeb3ContractCaller
+const contractCaller = constructEthersContractCaller(
+  {
+    ethersProviderOrSigner: signer,
+    EthersContract: ethers.Contract,
+  },
+  account
+); // alternatively constructViemContractCaller or constructWeb3ContractCaller
 const fetcher = constructAxiosFetcher(axios); // alternatively constructFetchFetcher
 
 const sdk = constructFullSDK({
@@ -166,24 +177,35 @@ const sdk = constructFullSDK({
 ```
 
 ### Partial SDK
+
 For bundle-size savvy developers, you can construct a lightweight version of the SDK and bring only the functions you need.
 
 e.g. for only getting rates and allowances:
 
 ```typescript
-import { constructPartialSDK, constructFetchFetcher, constructGetRate, constructGetBalances } from '@velora-dex/sdk';
+import {
+  constructPartialSDK,
+  constructFetchFetcher,
+  constructGetRate,
+  constructGetBalances,
+} from '@velora-dex/sdk';
 
 const fetcher = constructFetchFetcher(window.fetch);
 
-const sdk = constructPartialSDK({
-  chainId: 1,
-  fetcher,
-}, constructGetRate, constructGetBalances);
+const sdk = constructPartialSDK(
+  {
+    chainId: 1,
+    fetcher,
+  },
+  constructGetRate,
+  constructGetBalances
+);
 
 const priceRoute = await sdk.getRate(params);
 const allowance = await sdk.getAllowance(userAddress, tokenAddress);
 ```
---------------
+
+---
 
 ### Basic usage
 
@@ -210,8 +232,8 @@ const simpleSDK = constructSimpleSDK(
 );
 
 const amount = '1000000000000'; // wei
-const Token1 = '0x1234...'
-const Token2 = '0xabcde...'
+const Token1 = '0x1234...';
+const Token2 = '0xabcde...';
 
 const quote = await simpleSDK.quote.getQuote({
   srcToken: Token1, // Native token (ETH) is only supported in mode: 'market'
@@ -298,8 +320,8 @@ In v2 the Order is **built by the server** from the quoted route — you sign th
 
 ```ts
 const amount = '1000000000000'; // wei
-const Token1 = '0x1234...'
-const Token2 = '0xabcde...'
+const Token1 = '0x1234...';
+const Token2 = '0xabcde...';
 
 // ... from the quote endpoint (mode: 'delta' or 'all')
 const quote = await simpleSDK.quote.getQuote({
@@ -327,11 +349,13 @@ const deltaPriceDirect = await simpleSDK.delta.getDeltaPrice({
 });
 ```
 
-
 ### 2. Approve srcToken for DeltaContract
 
 ```ts
-const approveTxHash = await simpleSDK.delta.approveTokenForDelta(amount, Token1);
+const approveTxHash = await simpleSDK.delta.approveTokenForDelta(
+  amount,
+  Token1
+);
 ```
 
 Alternatively sign Permit (DAI or Permit1) or Permit2 TransferFrom with DeltaContract as the verifyingContract
@@ -344,7 +368,6 @@ const signature = await signer._signTypedData(domain, types, message);
 ```
 
 See more on accepted Permit variants in [Velora documentation](https://developers.velora.xyz/api/velora-api/velora-delta-api/build-a-delta-order-to-sign#supported-permits)
-
 
 ### 3. Build, sign and post a Delta Order
 
@@ -423,7 +446,7 @@ For more Delta protocol usage, and **Crosschain Delta Orders**, refer to [DELTA.
 
 For **External Delta Orders** (orders that delegate token handling to an external handler contract, enabling complex DeFi strategies like Aave collateral/debt swaps), refer to [EXTERNAL_ORDERS.md](./docs/EXTERNAL_ORDERS.md)
 
-------------
+---
 
 ### Advanced Delta usage
 
@@ -473,11 +496,17 @@ const sdk = constructPartialSDK(
   { chainId: 1, fetcher: constructFetchFetcher(fetch) },
   constructGetDeltaPrice,
   constructGetDeltaOrders,
-  constructGetBridgeRoutes,
+  constructGetBridgeRoutes
 );
 
-const price = await sdk.getDeltaPrice({ /* ... */ });
-const orders = await sdk.getDeltaOrders({ userAddress: account, page: 1, limit: 50 });
+const price = await sdk.getDeltaPrice({
+  /* ... */
+});
+const orders = await sdk.getDeltaOrders({
+  userAddress: account,
+  page: 1,
+  limit: 50,
+});
 ```
 
 A complete example (standard, external handler, TWAP, and order listing) is in [examples/delta](./src/examples/delta.ts).
@@ -499,7 +528,10 @@ const { checks, getters } = OrderHelpers;
 
 if (checks.isProductiveAuction(auction)) {
   // read-only, no SDK builder
-} else if (checks.isFillableAuction(auction) || checks.isDeltaAuction(auction)) {
+} else if (
+  checks.isFillableAuction(auction) ||
+  checks.isDeltaAuction(auction)
+) {
   // treat FillableOrder the same as a standard Order
 }
 
@@ -512,20 +544,20 @@ const unified = getters.getUnifiedDeltaOrderData(auction);
 // { srcChainId, destChainId, srcToken, destToken, swapSide, filledPercent, amounts, ... }
 ```
 
-------------
+---
 
 ### Market Swap handling
 
 #### A more detailed overview of the Trade Flow, Market variant.
 
-Unlike the Delta Order, a Market swap  requires the user themselves to submit a Swap transaction
+Unlike the Delta Order, a Market swap requires the user themselves to submit a Swap transaction
 
 ### 1. Get Market priceRoute from /v2/quote
 
 ```ts
 const amount = '1000000000000'; // wei
-const Token1 = '0x1234...'
-const Token2 = '0xabcde...'
+const Token1 = '0x1234...';
+const Token2 = '0xabcde...';
 
 const quote = await simpleSDK.quote.getQuote({
   srcToken: Token1,
@@ -537,11 +569,10 @@ const quote = await simpleSDK.quote.getQuote({
   mode: 'market',
   side: 'SELL', // or 'BUY'
   // partner: "..." // if available
-})
+});
 
 const priceRoute = quote.market;
 ```
-
 
 ### 2. Approve srcToken for TokenTransferProxy
 
@@ -559,7 +590,6 @@ const signature = await signer._signTypedData(domain, types, message);
 ```
 
 See more on accepted Permit variants in [Velora documentation](https://developers.velora.xyz/api/velora-api/velora-market-api/build-parameters-for-transaction)
-
 
 ### 3. Send Swap transaction
 
@@ -581,8 +611,7 @@ const swapTxHash = await signer.sendTransaction(txParams);
 
 #### See more details on `buildTx` parameters in [Velora documentation](https://developers.velora.xyz/api/velora-api/velora-market-api/build-parameters-for-transaction)
 
-------------------------
-
+---
 
 Refer to [SDK API documentation](docs/md/modules.md) for detailed documentation on the methods provided in this SDK.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ import {
   constructEthersContractCaller,
 } from '@velora-dex/sdk';
 
-const signer = ethers.Wallet.fromMnmemonic('__your_mnemonic__'); // or any other signer/provider
+const signer = ethers.Wallet.fromMnemonic('__your_mnemonic__'); // or any other signer/provider
 const account = '__signer_address__';
 
 const contractCaller = constructEthersContractCaller(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,7 @@ import {
 import {
   CancelDeltaOrderFunctions,
   CancelDeltaOrder,
+  BuildCancelDeltaOrder,
   SignCancelDeltaOrderRequest,
   PostCancelDeltaOrderRequest,
   constructCancelDeltaOrder,
@@ -439,6 +440,7 @@ export type {
   ApproveTokenForDeltaFunctions,
   CancelDeltaOrderFunctions,
   CancelDeltaOrder,
+  BuildCancelDeltaOrder,
   SignCancelDeltaOrderRequest,
   PostCancelDeltaOrderRequest,
   DeltaTokenModuleFunctions,

--- a/src/methods/delta/cancelDeltaOrder.ts
+++ b/src/methods/delta/cancelDeltaOrder.ts
@@ -7,6 +7,7 @@ import { constructGetDeltaContract } from './getDeltaContract';
 import {
   buildCancelDeltaOrderSignableData,
   type CancelDeltaOrderData,
+  type SignableCancelDeltaOrderData,
 } from './helpers/buildCancelDeltaOrderData';
 
 type SuccessResponse = { success: true };
@@ -15,6 +16,11 @@ type CancelDeltaOrderRequestParams = {
   orderIds: string[];
   signature: string;
 };
+
+export type BuildCancelDeltaOrder = (
+  params: CancelDeltaOrderData,
+  requestParams?: RequestParameters
+) => Promise<SignableCancelDeltaOrderData>;
 
 export type SignCancelDeltaOrderRequest = (
   params: CancelDeltaOrderData,
@@ -32,6 +38,8 @@ export type CancelDeltaOrder = (
 ) => Promise<SuccessResponse>;
 
 export type CancelDeltaOrderFunctions = {
+  /** @description Build the EIP-712 signable data for cancelling one or more Delta orders */
+  buildCancelDeltaOrder: BuildCancelDeltaOrder;
   signCancelDeltaOrderRequest: SignCancelDeltaOrderRequest;
   postCancelDeltaOrderRequest: PostCancelDeltaOrderRequest;
   /** @description Cancel one or more Delta orders via the v2 endpoint */
@@ -48,7 +56,7 @@ export const constructCancelDeltaOrder = (
 
   const { getDeltaContract } = constructGetDeltaContract(options);
 
-  const signCancelDeltaOrderRequest: SignCancelDeltaOrderRequest = async (
+  const buildCancelDeltaOrder: BuildCancelDeltaOrder = async (
     params,
     requestParams
   ) => {
@@ -57,11 +65,18 @@ export const constructCancelDeltaOrder = (
       throw new Error(`Delta is not available on chain ${options.chainId}`);
     }
 
-    const typedData = buildCancelDeltaOrderSignableData({
+    return buildCancelDeltaOrderSignableData({
       orderInput: params,
       paraswapDeltaAddress: ParaswapDelta,
       chainId: options.chainId,
     });
+  };
+
+  const signCancelDeltaOrderRequest: SignCancelDeltaOrderRequest = async (
+    params,
+    requestParams
+  ) => {
+    const typedData = await buildCancelDeltaOrder(params, requestParams);
 
     return options.contractCaller.signTypedDataCall(typedData);
   };
@@ -93,6 +108,7 @@ export const constructCancelDeltaOrder = (
   };
 
   return {
+    buildCancelDeltaOrder,
     signCancelDeltaOrderRequest,
     postCancelDeltaOrderRequest,
     cancelDeltaOrders,

--- a/tests/delta.test.ts
+++ b/tests/delta.test.ts
@@ -864,6 +864,47 @@ describe('Delta: cancel', () => {
     expect(postedBody.orderIds).toEqual(['a', 'b']);
     expect(postedBody.signature).toBe(FAKE_SIGNATURE);
   });
+
+  test('buildCancelDeltaOrder returns the EIP-712 signable data', async () => {
+    const fetcher = makeFetcher(({ url }) => {
+      if (url.includes('/adapters/contracts')) {
+        return {
+          AugustusSwapper: '0x',
+          TokenTransferProxy: '0x',
+          AugustusRFQ: '0x',
+          Executors: {},
+          ParaswapDelta: '0x1111111111111111111111111111111111111111',
+        };
+      }
+      throw new Error('unexpected');
+    });
+
+    const { buildCancelDeltaOrder } = constructCancelDeltaOrder({
+      apiURL: API_URL,
+      chainId: 1,
+      fetcher,
+      contractCaller: makeMockContractCaller(),
+    });
+
+    const signableData = await buildCancelDeltaOrder({
+      orderIds: ['a', 'b'],
+    });
+
+    expect(signableData).toEqual({
+      types: {
+        OrderCancellations: [{ name: 'orderIds', type: 'string[]' }],
+      },
+      domain: {
+        name: 'Portikus',
+        version: '2.0.0',
+        chainId: 1,
+        verifyingContract: '0x1111111111111111111111111111111111111111',
+      },
+      data: {
+        orderIds: ['a', 'b'],
+      },
+    });
+  });
 });
 
 describe('Delta: live API contract', () => {
@@ -987,6 +1028,7 @@ describe('Delta: SDK wiring', () => {
     expect(typeof sdk.submitExternalDeltaOrder).toBe('function');
     expect(typeof sdk.submitTWAPDeltaOrder).toBe('function');
     expect(typeof sdk.cancelDeltaOrders).toBe('function');
+    expect(typeof sdk.buildCancelDeltaOrder).toBe('function');
     expect(typeof sdk.isTokenSupportedInDelta).toBe('function');
     expect(typeof sdk.getAgentsList).toBe('function');
     // reused v1 utilities


### PR DESCRIPTION
Adds `buildCancelDeltaOrder` in `constructCancelDeltaOrder` factory


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API on the cancel path with a small internal refactor; existing `cancelDeltaOrders` behavior is unchanged aside from sharing the new build step.
> 
> **Overview**
> Adds **`buildCancelDeltaOrder`** on `constructCancelDeltaOrder` / `sdk.delta.*`, returning EIP-712 **`SignableCancelDeltaOrderData`** (Portikus domain + `OrderCancellations` with `orderIds`) after resolving the ParaswapDelta contract. **`signCancelDeltaOrderRequest`** now builds typed data through this helper before calling `signTypedDataCall`, so apps can inspect or sign cancel payloads outside the bundled signer.
> 
> Exports the **`BuildCancelDeltaOrder`** type from the package entrypoint, documents the build → sign → post cancel flow in **CLAUDE.md**, bumps **`@velora-dex/sdk` to 10.1.0**, and adds unit coverage plus an assertion that **`constructAllDeltaOrdersHandlers`** exposes `buildCancelDeltaOrder`. **README.md** changes are mostly formatting; command examples use **pnpm** instead of **yarn**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0dbced2dd626b5b057542e2de64e5a438c4cac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->