### PR TITLE
Feat/curated tokens

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,7 +33,7 @@ const config: HardhatUserConfig = {
       // dynamically switch between networks configured here
       // by calling `hre.switchNetwork(networkName)` thanks to hardhat-switch-network plugin
       gasPrice: 8e9,
-      initialBaseFeePerGas: 1e8, // will break if used with a chain without eip1559
+      initialBaseFeePerGas: 0, // will break if used with a chain without eip1559
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.2.0-dev.1",
+  "version": "10.2.0",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.1.0",
+  "version": "10.2.0-dev.0",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.2.0-dev.0",
+  "version": "10.2.0-dev.1",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/helpers/providers/uri.ts
+++ b/src/helpers/providers/uri.ts
@@ -1,0 +1,41 @@
+const ipfsRegEx = /^(ipfs|ipns):\/\/(.*)$/i;
+
+const IPFStransformer: TransformURI = (uri) => {
+  const match = uri.match(ipfsRegEx);
+  // likely http:// , https:// or // uri
+  if (!match) return null;
+
+  const [, protocol, hash] = match;
+  if (!protocol || !hash) return null;
+
+  return `https://ipfs.io/${protocol}/${hash}/`;
+};
+
+// takes URI, returns string if applicable or null
+type TransformURI = (uri: string) => string | null;
+
+const createURItoHttpURLTransformer = (
+  ...transformers: TransformURI[]
+): ((uri: string) => string) => {
+  return (uri) => {
+    // try each transformer
+    const httpURL = transformers.reduce<string | null>(
+      (result, transformer) => {
+        // as soon as transformer returns string, skip further transformers
+        if (result !== null) return result;
+        // no transformer returned string yet, so try current transformer
+        return transformer(uri);
+      },
+      null
+    );
+
+    return httpURL || uri;
+  };
+};
+
+// uri can be
+// IPFS  ipfs://QmV8AfDE8GFSGQvt3vck8EwAzsPuNTmtP8VcQJE3qxRPaZ
+// IPNS  ipns://app.uniswap.org
+// http, https or // (match current protocol)
+
+export const uriToHttpURL = createURItoHttpURLTransformer(IPFStransformer);

--- a/src/helpers/providers/uri.ts
+++ b/src/helpers/providers/uri.ts
@@ -11,7 +11,7 @@ const IPFStransformer: TransformURI = (uri) => {
   // only append `/` to a bare root; a path segment (`.../logo.png`)
   // must keep its exact ending or gateways may resolve it differently
   const suffix = hash.includes('/') ? '' : '/';
-  return `https://ipfs.io/${protocol}/${hash}${suffix}`;
+  return `https://ipfs.io/${protocol}/${hash}${suffix}`.toLowerCase();
 };
 
 // takes URI, returns string if applicable or null

--- a/src/helpers/providers/uri.ts
+++ b/src/helpers/providers/uri.ts
@@ -11,7 +11,8 @@ const IPFStransformer: TransformURI = (uri) => {
   // only append `/` to a bare root; a path segment (`.../logo.png`)
   // must keep its exact ending or gateways may resolve it differently
   const suffix = hash.includes('/') ? '' : '/';
-  return `https://ipfs.io/${protocol}/${hash}${suffix}`.toLowerCase();
+  // hash stays as-is: base58 CIDs (Qm…) are case-sensitive
+  return `https://ipfs.io/${protocol.toLowerCase()}/${hash}${suffix}`;
 };
 
 // takes URI, returns string if applicable or null

--- a/src/helpers/providers/uri.ts
+++ b/src/helpers/providers/uri.ts
@@ -8,7 +8,10 @@ const IPFStransformer: TransformURI = (uri) => {
   const [, protocol, hash] = match;
   if (!protocol || !hash) return null;
 
-  return `https://ipfs.io/${protocol}/${hash}/`;
+  // only append `/` to a bare root; a path segment (`.../logo.png`)
+  // must keep its exact ending or gateways may resolve it differently
+  const suffix = hash.includes('/') ? '' : '/';
+  return `https://ipfs.io/${protocol}/${hash}${suffix}`;
 };
 
 // takes URI, returns string if applicable or null

--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -1,6 +1,6 @@
 import type { MarkOptional } from 'ts-essentials';
 import { uriToHttpURL } from './providers/uri';
-import { ApiToken, TokenListItem } from '../types';
+import type { ApiToken, TokenListItem } from '../types';
 
 /**
  * @type hex token or account address

--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -1,4 +1,6 @@
 import type { MarkOptional } from 'ts-essentials';
+import { uriToHttpURL } from './providers/uri';
+import { ApiToken, TokenListItem } from '../types';
 
 /**
  * @type hex token or account address
@@ -38,9 +40,10 @@ export type Token = {
   address: string;
   decimals: number;
   symbol?: string | undefined;
-  tags?: string[] | undefined;
-  sources?: string[] | undefined;
-  categories?: string[] | undefined;
+  name?: string | undefined;
+  tags: string[];
+  sources: string[];
+  categories: string[];
   tokenType: LendingToken | TokenType;
   mainConnector: string;
   connectors: string[];
@@ -50,13 +53,16 @@ export type Token = {
   balance?: string | undefined;
 };
 
-type ConstructTokenInput = MarkOptional<
-  Token,
-  // these props are constructed from other, required props
-  'tokenType' | 'mainConnector' | 'connectors' | 'network'
->;
+type DefaultedKeys =
+  | 'tokenType'
+  | 'mainConnector'
+  | 'connectors'
+  | 'network'
+  | 'sources'
+  | 'categories'
+  | 'tags';
 
-type DefaultedKeys = 'tokenType' | 'mainConnector' | 'connectors' | 'network';
+type ConstructTokenInput = MarkOptional<Token, DefaultedKeys>;
 
 export const constructToken = <T extends ConstructTokenInput>(
   tokenProps: T
@@ -66,6 +72,9 @@ export const constructToken = <T extends ConstructTokenInput>(
     mainConnector = 'ETH',
     connectors: connectorsInput = [],
     network = 1,
+    sources = [],
+    categories = [],
+    tags = [],
     ...rest
   } = tokenProps;
 
@@ -77,6 +86,23 @@ export const constructToken = <T extends ConstructTokenInput>(
     connectors,
     mainConnector,
     network,
+    sources,
+    categories,
+    tags,
     ...rest,
   };
 };
+
+export function constructApiToken(t: TokenListItem): ApiToken {
+  return constructToken({
+    address: t.address,
+    decimals: t.decimals,
+    symbol: t.symbol,
+    name: t.name,
+    network: t.chainId,
+    sources: t.sources,
+    categories: t.categories,
+    img: t.logoURI ? uriToHttpURL(t.logoURI) : undefined,
+    tags: t.tags,
+  });
+}

--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -38,6 +38,9 @@ export type Token = {
   address: string;
   decimals: number;
   symbol?: string | undefined;
+  tags?: string[] | undefined;
+  sources?: string[] | undefined;
+  categories?: string[] | undefined;
   tokenType: LendingToken | TokenType;
   mainConnector: string;
   connectors: string[];
@@ -53,7 +56,11 @@ type ConstructTokenInput = MarkOptional<
   'tokenType' | 'mainConnector' | 'connectors' | 'network'
 >;
 
-export const constructToken = (tokenProps: ConstructTokenInput): Token => {
+type DefaultedKeys = 'tokenType' | 'mainConnector' | 'connectors' | 'network';
+
+export const constructToken = <T extends ConstructTokenInput>(
+  tokenProps: T
+): Omit<T, DefaultedKeys> & Required<Pick<Token, DefaultedKeys>> => {
   const {
     tokenType = 'ERC20',
     mainConnector = 'ETH',

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,13 @@ import {
   GetRateInput,
 } from './methods/swap/rates';
 import { constructSwapTx, GetSwapTxFunctions } from './methods/swap/swapTx';
-import { constructGetTokens, GetTokensFunctions } from './methods/swap/token';
+import {
+  constructGetTokens,
+  GetTokensFunctions,
+  GetAllTokens,
+  GetTokens,
+  GetTokensParams,
+} from './methods/swap/token';
 import { BuildTxFunctions, constructBuildTx } from './methods/swap/transaction';
 
 import {
@@ -379,7 +385,6 @@ export type {
   GetBalancesFunctions,
   GetSpenderFunctions,
   AdaptersContractsResult,
-  GetTokensFunctions,
   GetAdaptersFunctions,
   GetRateFunctions,
   GetRateInput,
@@ -482,6 +487,11 @@ export type {
   QuoteWithDeltaPrice,
   QuoteWithMarketPrice,
   QuoteWithMarketPriceAsFallback,
+  // types for GetToken methods
+  GetTokensFunctions,
+  GetTokens,
+  GetAllTokens,
+  GetTokensParams,
   //common
   ConstructFetchInput,
   ContractCallerFunctions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   GetAllTokens,
   GetTokens,
   GetTokensParams,
+  GetTokenCategories,
 } from './methods/swap/token';
 import { BuildTxFunctions, constructBuildTx } from './methods/swap/transaction';
 
@@ -106,6 +107,7 @@ import type {
   APIVersion,
   ExtraFetchParams,
   PaginatedResponse,
+  TokenCategory,
 } from './types';
 
 // ── Delta ─────────────────────────────────────────────────────────────────
@@ -492,6 +494,8 @@ export type {
   GetTokens,
   GetAllTokens,
   GetTokensParams,
+  GetTokenCategories,
+  TokenCategory,
   //common
   ConstructFetchInput,
   ContractCallerFunctions,

--- a/src/methods/swap/balance.ts
+++ b/src/methods/swap/balance.ts
@@ -44,6 +44,7 @@ export const isAllowance = (
   return 'allowance' in arg;
 };
 
+/** @deprecated Will be removed in the next major version. */
 export type GetBalancesFunctions = {
   getBalance: GetBalance;
   getBalances: GetBalances;
@@ -53,6 +54,7 @@ export type GetBalancesFunctions = {
 
 const NOT_FOUND_RESPONSE = { message: 'Not Found' } as const;
 
+/** @deprecated Will be removed in the next major version. */
 export const constructGetBalances = ({
   apiURL = API_URL,
   chainId,

--- a/src/methods/swap/spender.ts
+++ b/src/methods/swap/spender.ts
@@ -6,9 +6,9 @@ import type {
   RequestParameters,
 } from '../../types';
 
-export type GetSpender = (
+export type GetSpender<T = Address> = (
   requestParams?: RequestParameters
-) => Promise<Address>;
+) => Promise<T>;
 type GetContracts = (
   requestParams?: RequestParameters
 ) => Promise<AdaptersContractsResult>;
@@ -17,6 +17,7 @@ export type GetSpenderFunctions = {
   getSpender: GetSpender;
   getAugustusSwapper: GetSpender;
   getAugustusRFQ: GetSpender;
+  getDelta: GetSpender<Address | null>;
   getContracts: GetContracts;
 };
 
@@ -72,5 +73,16 @@ export const constructGetSpender = ({
     return AugustusRFQ;
   };
 
-  return { getContracts, getSpender, getAugustusSwapper, getAugustusRFQ };
+  const getDelta: GetSpender<Address | null> = async (requestParams) => {
+    const { ParaswapDelta } = await getContracts(requestParams);
+    return ParaswapDelta || null;
+  };
+
+  return {
+    getContracts,
+    getSpender,
+    getAugustusSwapper,
+    getAugustusRFQ,
+    getDelta,
+  };
 };

--- a/src/methods/swap/token.ts
+++ b/src/methods/swap/token.ts
@@ -1,52 +1,28 @@
 import { API_URL } from '../../constants';
-import { constructToken } from '../../helpers/token';
+import { constructApiToken } from '../../helpers/token';
 import { constructSearchString } from '../../helpers/misc';
 import type {
+  ApiToken,
   RequestParameters,
   ConstructFetchInput,
-  Token as SDKToken,
   TokenListApiResponse,
-  TokenListItem,
 } from '../../types';
-import { MarkRequired, Prettify } from 'ts-essentials';
-import { uriToHttpURL } from '../../helpers/providers/uri';
 
-type GetTokensParams = { category?: string };
+export type GetTokensParams = { category?: string };
 
-type Token = Prettify<
-  MarkRequired<
-    Omit<SDKToken, 'allowance' | 'balance'>,
-    'sources' | 'categories'
-  > & { name: string }
->;
-
-type GetTokens = (
+export type GetTokens = (
   options?: GetTokensParams,
   requestParams?: RequestParameters
-) => Promise<Token[]>;
-type GetAllTokens = (
+) => Promise<ApiToken[]>;
+export type GetAllTokens = (
   options?: GetTokensParams,
   requestParams?: RequestParameters
-) => Promise<Token[]>;
+) => Promise<ApiToken[]>;
 
 export type GetTokensFunctions = {
   getTokens: GetTokens;
   getAllTokens: GetAllTokens;
 };
-
-function makeTokenFromApiToken(t: TokenListItem): Token {
-  return constructToken({
-    address: t.address,
-    decimals: t.decimals,
-    symbol: t.symbol,
-    name: t.name,
-    network: t.chainId,
-    sources: t.sources,
-    categories: t.categories,
-    img: t.logoURI ? uriToHttpURL(t.logoURI) : undefined,
-    tags: t.tags,
-  });
-}
 
 export const constructGetTokens = ({
   apiURL = API_URL,
@@ -65,7 +41,7 @@ export const constructGetTokens = ({
       requestParams,
     });
 
-    return data.tokens.map(makeTokenFromApiToken);
+    return data.tokens.map(constructApiToken);
   };
 
   const getAllTokens: GetAllTokens = async (
@@ -83,7 +59,7 @@ export const constructGetTokens = ({
       requestParams,
     });
 
-    return data.tokens.map(makeTokenFromApiToken);
+    return data.tokens.map(constructApiToken);
   };
 
   return { getTokens, getAllTokens };

--- a/src/methods/swap/token.ts
+++ b/src/methods/swap/token.ts
@@ -6,8 +6,10 @@ import type {
   ConstructFetchInput,
   Token as SDKToken,
   TokenListApiResponse,
+  TokenListItem,
 } from '../../types';
 import { MarkRequired, Prettify } from 'ts-essentials';
+import { uriToHttpURL } from '../../helpers/providers/uri';
 
 type GetTokensParams = { category?: string };
 
@@ -32,6 +34,20 @@ export type GetTokensFunctions = {
   getAllTokens: GetAllTokens;
 };
 
+function makeTokenFromApiToken(t: TokenListItem): Token {
+  return constructToken({
+    address: t.address,
+    decimals: t.decimals,
+    symbol: t.symbol,
+    name: t.name,
+    network: t.chainId,
+    sources: t.sources,
+    categories: t.categories,
+    img: t.logoURI ? uriToHttpURL(t.logoURI) : undefined,
+    tags: t.tags,
+  });
+}
+
 export const constructGetTokens = ({
   apiURL = API_URL,
   chainId,
@@ -49,7 +65,7 @@ export const constructGetTokens = ({
       requestParams,
     });
 
-    return data.tokens.map(constructToken);
+    return data.tokens.map(makeTokenFromApiToken);
   };
 
   const getAllTokens: GetAllTokens = async (
@@ -67,7 +83,7 @@ export const constructGetTokens = ({
       requestParams,
     });
 
-    return data.tokens.map(constructToken);
+    return data.tokens.map(makeTokenFromApiToken);
   };
 
   return { getTokens, getAllTokens };

--- a/src/methods/swap/token.ts
+++ b/src/methods/swap/token.ts
@@ -10,10 +10,17 @@ import type {
 
 export type GetTokensParams = { category?: string };
 
-export type GetTokens = (
-  options?: GetTokensParams,
-  requestParams?: RequestParameters
-) => Promise<ApiToken[]>;
+export type GetTokens = {
+  (
+    options?: GetTokensParams,
+    requestParams?: RequestParameters
+  ): Promise<ApiToken[]>;
+  /**
+   * @deprecated Passing RequestParameters as the first argument is deprecated.
+   * Pass it as the second argument instead: `getTokens({}, requestParams)`
+   */
+  (requestParams?: RequestParameters): Promise<ApiToken[]>;
+};
 export type GetAllTokens = (
   options?: GetTokensParams,
   requestParams?: RequestParameters
@@ -29,7 +36,10 @@ export const constructGetTokens = ({
   chainId,
   fetcher,
 }: ConstructFetchInput): GetTokensFunctions => {
-  const getTokens: GetTokens = async ({ category } = {}, requestParams) => {
+  const getTokens: GetTokens = async (
+    { category, ..._requestParams }: GetTokensParams | RequestParameters = {},
+    requestParams?: RequestParameters
+  ) => {
     // always pass explicit type to make sure UrlSearchParams are correct
     const query = constructSearchString<GetTokensParams>({ category });
 
@@ -38,7 +48,10 @@ export const constructGetTokens = ({
     const data = await fetcher<TokenListApiResponse>({
       url: fetchURL,
       method: 'GET',
-      requestParams,
+      requestParams: {
+        ..._requestParams,
+        ...requestParams,
+      },
     });
 
     return data.tokens.map(constructApiToken);

--- a/src/methods/swap/token.ts
+++ b/src/methods/swap/token.ts
@@ -6,15 +6,16 @@ import type {
   RequestParameters,
   ConstructFetchInput,
   TokenListApiResponse,
+  TokenCategory,
+  TokenCategoriesApiResponse,
 } from '../../types';
 
 export type GetTokensParams = { category?: string };
 
 export type GetTokens = {
-  (
-    options?: GetTokensParams,
-    requestParams?: RequestParameters
-  ): Promise<ApiToken[]>;
+  (options?: GetTokensParams, requestParams?: RequestParameters): Promise<
+    ApiToken[]
+  >;
   /**
    * @deprecated Passing RequestParameters as the first argument is deprecated.
    * Pass it as the second argument instead: `getTokens({}, requestParams)`
@@ -25,10 +26,14 @@ export type GetAllTokens = (
   options?: GetTokensParams,
   requestParams?: RequestParameters
 ) => Promise<ApiToken[]>;
+export type GetTokenCategories = (
+  requestParams?: RequestParameters
+) => Promise<TokenCategory[]>;
 
 export type GetTokensFunctions = {
   getTokens: GetTokens;
   getAllTokens: GetAllTokens;
+  getTokenCategories: GetTokenCategories;
 };
 
 export const constructGetTokens = ({
@@ -75,5 +80,17 @@ export const constructGetTokens = ({
     return data.tokens.map(constructApiToken);
   };
 
-  return { getTokens, getAllTokens };
+  const getTokenCategories: GetTokenCategories = async (requestParams) => {
+    const fetchURL = `${apiURL}/fiat/tokens/categories` as const;
+
+    const data = await fetcher<TokenCategoriesApiResponse>({
+      url: fetchURL,
+      method: 'GET',
+      requestParams,
+    });
+
+    return data.categories;
+  };
+
+  return { getTokens, getAllTokens, getTokenCategories };
 };

--- a/src/methods/swap/token.ts
+++ b/src/methods/swap/token.ts
@@ -1,16 +1,35 @@
 import { API_URL } from '../../constants';
 import { constructToken } from '../../helpers/token';
+import { constructSearchString } from '../../helpers/misc';
 import type {
   RequestParameters,
   ConstructFetchInput,
-  Token,
-  TokensApiResponse,
+  Token as SDKToken,
+  TokenListApiResponse,
 } from '../../types';
+import { MarkRequired, Prettify } from 'ts-essentials';
 
-type GetTokens = (extra?: RequestParameters) => Promise<Token[]>;
+type GetTokensParams = { category?: string };
+
+type Token = Prettify<
+  MarkRequired<
+    Omit<SDKToken, 'allowance' | 'balance'>,
+    'sources' | 'categories'
+  > & { name: string }
+>;
+
+type GetTokens = (
+  options?: GetTokensParams,
+  requestParams?: RequestParameters
+) => Promise<Token[]>;
+type GetAllTokens = (
+  options?: GetTokensParams,
+  requestParams?: RequestParameters
+) => Promise<Token[]>;
 
 export type GetTokensFunctions = {
   getTokens: GetTokens;
+  getAllTokens: GetAllTokens;
 };
 
 export const constructGetTokens = ({
@@ -18,18 +37,38 @@ export const constructGetTokens = ({
   chainId,
   fetcher,
 }: ConstructFetchInput): GetTokensFunctions => {
-  const fetchURL = `${apiURL}/tokens/${chainId}` as const;
+  const getTokens: GetTokens = async ({ category } = {}, requestParams) => {
+    // always pass explicit type to make sure UrlSearchParams are correct
+    const query = constructSearchString<GetTokensParams>({ category });
 
-  const getTokens: GetTokens = async (requestParams) => {
-    const data = await fetcher<TokensApiResponse>({
+    const fetchURL = `${apiURL}/fiat/tokens/${chainId}${query}` as const;
+
+    const data = await fetcher<TokenListApiResponse>({
       url: fetchURL,
       method: 'GET',
       requestParams,
     });
 
-    const tokens = data.tokens.map(constructToken);
-    return tokens;
+    return data.tokens.map(constructToken);
   };
 
-  return { getTokens };
+  const getAllTokens: GetAllTokens = async (
+    { category } = {},
+    requestParams
+  ) => {
+    // always pass explicit type to make sure UrlSearchParams are correct
+    const query = constructSearchString<GetTokensParams>({ category });
+
+    const fetchURL = `${apiURL}/fiat/tokens/all${query}` as const;
+
+    const data = await fetcher<TokenListApiResponse>({
+      url: fetchURL,
+      method: 'GET',
+      requestParams,
+    });
+
+    return data.tokens.map(constructToken);
+  };
+
+  return { getTokens, getAllTokens };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,13 +146,13 @@ export interface TokenApiResponse {
   token?: TokenFromApi;
 }
 
-type TokenListItem = {
-  network: number;
+export type TokenListItem = {
+  chainId: number;
   address: string;
   name: string;
   decimals: number;
   symbol: string;
-  img?: string;
+  logoURI?: string;
   tags?: string[];
   sources: string[];
   categories: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ import type {
 } from './helpers/token';
 import type { SignableTypedData } from './methods/common/orders/buildOrderData';
 import { TransactionParams } from './methods/swap/transaction';
-import { MarkRequired, Prettify } from 'ts-essentials';
+import type { MarkRequired, Prettify } from 'ts-essentials';
 
 export type {
   Address,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,12 +47,14 @@ interface FetcherInputBase<URL extends string = string> {
   headers?: Record<string, string>;
   requestParams?: RequestParameters;
 }
-export interface FetcherGetInput<URL extends string = string>
-  extends FetcherInputBase<URL> {
+export interface FetcherGetInput<
+  URL extends string = string,
+> extends FetcherInputBase<URL> {
   method: 'GET';
 }
-export interface FetcherPostInput<URL extends string = string>
-  extends FetcherInputBase<URL> {
+export interface FetcherPostInput<
+  URL extends string = string,
+> extends FetcherInputBase<URL> {
   method: 'POST';
   data: Record<string, any>;
 }
@@ -96,13 +98,15 @@ interface ContractCallInput<T extends string> {
   args: any[];
 }
 
-export interface ContractCallStaticInput<T extends string>
-  extends ContractCallInput<T> {
+export interface ContractCallStaticInput<
+  T extends string,
+> extends ContractCallInput<T> {
   overrides: StaticCallOverrides;
 }
 
-interface ContractCallTransactionInput<T extends string>
-  extends ContractCallInput<T> {
+interface ContractCallTransactionInput<
+  T extends string,
+> extends ContractCallInput<T> {
   overrides: TxSendOverrides;
 }
 
@@ -125,7 +129,7 @@ export interface ContractCallerFunctions<T> {
 
 export interface ConstructProviderFetchInput<
   T,
-  D extends keyof ContractCallerFunctions<T> = keyof ContractCallerFunctions<T>
+  D extends keyof ContractCallerFunctions<T> = keyof ContractCallerFunctions<T>,
 > extends ConstructFetchInput {
   contractCaller: Pick<ContractCallerFunctions<T>, D>;
 }
@@ -142,13 +146,25 @@ export interface TokenApiResponse {
   token?: TokenFromApi;
 }
 
+type TokenListItem = {
+  network: number;
+  address: string;
+  name: string;
+  decimals: number;
+  symbol: string;
+  img?: string;
+  tags?: string[];
+  sources: string[];
+  categories: string[];
+};
+
+export interface TokenListApiResponse {
+  tokens: TokenListItem[];
+}
+
 // if no extra keys in Checking, return Checking, otherwise never
-export type NoExtraKeysCheck<Checking, CheckAgainst> = Exclude<
-  keyof Checking,
-  keyof CheckAgainst
-> extends never
-  ? Checking
-  : never;
+export type NoExtraKeysCheck<Checking, CheckAgainst> =
+  Exclude<keyof Checking, keyof CheckAgainst> extends never ? Checking : never;
 
 export type PriceRouteApiResponse = {
   priceRoute: OptimalRate;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,14 +48,12 @@ interface FetcherInputBase<URL extends string = string> {
   headers?: Record<string, string>;
   requestParams?: RequestParameters;
 }
-export interface FetcherGetInput<
-  URL extends string = string,
-> extends FetcherInputBase<URL> {
+export interface FetcherGetInput<URL extends string = string>
+  extends FetcherInputBase<URL> {
   method: 'GET';
 }
-export interface FetcherPostInput<
-  URL extends string = string,
-> extends FetcherInputBase<URL> {
+export interface FetcherPostInput<URL extends string = string>
+  extends FetcherInputBase<URL> {
   method: 'POST';
   data: Record<string, any>;
 }
@@ -99,15 +97,13 @@ interface ContractCallInput<T extends string> {
   args: any[];
 }
 
-export interface ContractCallStaticInput<
-  T extends string,
-> extends ContractCallInput<T> {
+export interface ContractCallStaticInput<T extends string>
+  extends ContractCallInput<T> {
   overrides: StaticCallOverrides;
 }
 
-interface ContractCallTransactionInput<
-  T extends string,
-> extends ContractCallInput<T> {
+interface ContractCallTransactionInput<T extends string>
+  extends ContractCallInput<T> {
   overrides: TxSendOverrides;
 }
 
@@ -130,7 +126,7 @@ export interface ContractCallerFunctions<T> {
 
 export interface ConstructProviderFetchInput<
   T,
-  D extends keyof ContractCallerFunctions<T> = keyof ContractCallerFunctions<T>,
+  D extends keyof ContractCallerFunctions<T> = keyof ContractCallerFunctions<T>
 > extends ConstructFetchInput {
   contractCaller: Pick<ContractCallerFunctions<T>, D>;
 }
@@ -168,8 +164,12 @@ export type ApiToken = Prettify<
 >;
 
 // if no extra keys in Checking, return Checking, otherwise never
-export type NoExtraKeysCheck<Checking, CheckAgainst> =
-  Exclude<keyof Checking, keyof CheckAgainst> extends never ? Checking : never;
+export type NoExtraKeysCheck<Checking, CheckAgainst> = Exclude<
+  keyof Checking,
+  keyof CheckAgainst
+> extends never
+  ? Checking
+  : never;
 
 export type PriceRouteApiResponse = {
   priceRoute: OptimalRate;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import type {
 } from './helpers/token';
 import type { SignableTypedData } from './methods/common/orders/buildOrderData';
 import { TransactionParams } from './methods/swap/transaction';
+import { MarkRequired, Prettify } from 'ts-essentials';
 
 export type {
   Address,
@@ -161,6 +162,10 @@ export type TokenListItem = {
 export interface TokenListApiResponse {
   tokens: TokenListItem[];
 }
+
+export type ApiToken = Prettify<
+  MarkRequired<Omit<Token, 'allowance' | 'balance'>, 'symbol' | 'name'>
+>;
 
 // if no extra keys in Checking, return Checking, otherwise never
 export type NoExtraKeysCheck<Checking, CheckAgainst> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,15 @@ export interface TokenListApiResponse {
   tokens: TokenListItem[];
 }
 
+export type TokenCategory = {
+  id: string;
+  name: string;
+};
+
+export interface TokenCategoriesApiResponse {
+  categories: TokenCategory[];
+}
+
 export type ApiToken = Prettify<
   MarkRequired<Omit<Token, 'allowance' | 'balance'>, 'symbol' | 'name'>
 >;

--- a/tests/partialSdk.test.ts
+++ b/tests/partialSdk.test.ts
@@ -167,10 +167,13 @@ describe.each([
         decimals: expect.any(Number),
         name: expect.any(String),
         network: expect.any(Number),
-        sources: expect.any(Array),
-        categories: expect.any(Array),
       })
     );
+    // Array.isArray instead of expect.any(Array): with the native fetch
+    // fetcher these arrays come from the host realm, so `instanceof Array`
+    // (which expect.any relies on) is false inside jest's sandbox
+    expect(Array.isArray(tokens[0]?.sources)).toBe(true);
+    expect(Array.isArray(tokens[0]?.categories)).toBe(true);
 
     // API fields are mapped to the SDK Token shape, not passed through
     expect(tokens[0]).not.toHaveProperty('chainId');

--- a/tests/partialSdk.test.ts
+++ b/tests/partialSdk.test.ts
@@ -219,6 +219,19 @@ describe.each([
     }
   });
 
+  test('Get_TokenCategories', async () => {
+    const categories = await sdk.getTokenCategories();
+
+    expect(Array.isArray(categories)).toBe(true);
+    expect(categories.length).toBeGreaterThan(0);
+    expect(categories[0]).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        name: expect.any(String),
+      })
+    );
+  });
+
   test('Get_Rates', async () => {
     const priceRoute = await sdk.getRate({
       srcToken: ETH,

--- a/tests/partialSdk.test.ts
+++ b/tests/partialSdk.test.ts
@@ -165,8 +165,21 @@ describe.each([
         symbol: expect.any(String),
         address: expect.any(String),
         decimals: expect.any(Number),
+        name: expect.any(String),
+        network: expect.any(Number),
+        sources: expect.any(Array),
+        categories: expect.any(Array),
       })
     );
+
+    // API fields are mapped to the SDK Token shape, not passed through
+    expect(tokens[0]).not.toHaveProperty('chainId');
+    expect(tokens[0]).not.toHaveProperty('logoURI');
+
+    // ipfs:// and ipns:// logo URIs are converted to http gateway URLs
+    for (const { img } of tokens) {
+      if (img) expect(img).not.toMatch(/^ip[fn]s:\/\//i);
+    }
   });
 
   test('Get_Rates', async () => {

--- a/tests/partialSdk.test.ts
+++ b/tests/partialSdk.test.ts
@@ -185,6 +185,40 @@ describe.each([
     }
   });
 
+  test('Get_AllTokens', async () => {
+    const tokens = await sdk.getAllTokens();
+
+    expect(Array.isArray(tokens)).toBe(true);
+    expect(tokens.length).toBeGreaterThan(0);
+    expect(tokens[0]).toEqual(
+      expect.objectContaining({
+        symbol: expect.any(String),
+        address: expect.any(String),
+        decimals: expect.any(Number),
+        name: expect.any(String),
+        network: expect.any(Number),
+      })
+    );
+    // Array.isArray instead of expect.any(Array): with the native fetch
+    // fetcher these arrays come from the host realm, so `instanceof Array`
+    // (which expect.any relies on) is false inside jest's sandbox
+    expect(Array.isArray(tokens[0]?.sources)).toBe(true);
+    expect(Array.isArray(tokens[0]?.categories)).toBe(true);
+
+    // API fields are mapped to the SDK Token shape, not passed through
+    expect(tokens[0]).not.toHaveProperty('chainId');
+    expect(tokens[0]).not.toHaveProperty('logoURI');
+
+    // /tokens/all is not scoped to the SDK chainId, tokens span networks
+    const networks = new Set(tokens.map((t) => t.network));
+    expect(networks.size).toBeGreaterThan(1);
+
+    // ipfs:// and ipns:// logo URIs are converted to http gateway URLs
+    for (const { img } of tokens) {
+      if (img) expect(img).not.toMatch(/^ip[fn]s:\/\//i);
+    }
+  });
+
   test('Get_Rates', async () => {
     const priceRoute = await sdk.getRate({
       srcToken: ETH,

--- a/tests/partialSdk.test.ts
+++ b/tests/partialSdk.test.ts
@@ -209,7 +209,7 @@ describe.each([
     expect(tokens[0]).not.toHaveProperty('chainId');
     expect(tokens[0]).not.toHaveProperty('logoURI');
 
-    // /tokens/all is not scoped to the SDK chainId, tokens span networks
+    // /fiat/tokens/all is not scoped to the SDK chainId, tokens span networks
     const networks = new Set(tokens.map((t) => t.network));
     expect(networks.size).toBeGreaterThan(1);
 

--- a/tests/simpleSdk.test.ts
+++ b/tests/simpleSdk.test.ts
@@ -134,7 +134,7 @@ describe.each([
     expect(tokens[0]).not.toHaveProperty('chainId');
     expect(tokens[0]).not.toHaveProperty('logoURI');
 
-    // /tokens/all is not scoped to the SDK chainId, tokens span networks
+    // /fiat/tokens/all is not scoped to the SDK chainId, tokens span networks
     const networks = new Set(tokens.map((t) => t.network));
     expect(networks.size).toBeGreaterThan(1);
 

--- a/tests/simpleSdk.test.ts
+++ b/tests/simpleSdk.test.ts
@@ -90,8 +90,21 @@ describe.each([
         symbol: expect.any(String),
         address: expect.any(String),
         decimals: expect.any(Number),
+        name: expect.any(String),
+        network: expect.any(Number),
+        sources: expect.any(Array),
+        categories: expect.any(Array),
       })
     );
+
+    // API fields are mapped to the SDK Token shape, not passed through
+    expect(tokens[0]).not.toHaveProperty('chainId');
+    expect(tokens[0]).not.toHaveProperty('logoURI');
+
+    // ipfs:// and ipns:// logo URIs are converted to http gateway URLs
+    for (const { img } of tokens) {
+      if (img) expect(img).not.toMatch(/^ip[fn]s:\/\//i);
+    }
   });
 
   test('Get_Rates', async () => {

--- a/tests/simpleSdk.test.ts
+++ b/tests/simpleSdk.test.ts
@@ -144,6 +144,19 @@ describe.each([
     }
   });
 
+  test('Get_TokenCategories', async () => {
+    const categories = await sdk.swap.getTokenCategories();
+
+    expect(Array.isArray(categories)).toBe(true);
+    expect(categories.length).toBeGreaterThan(0);
+    expect(categories[0]).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        name: expect.any(String),
+      })
+    );
+  });
+
   test('Get_Rates', async () => {
     const priceRoute = await sdk.swap.getRate({
       srcToken: ETH,

--- a/tests/simpleSdk.test.ts
+++ b/tests/simpleSdk.test.ts
@@ -110,6 +110,40 @@ describe.each([
     }
   });
 
+  test('Get_AllTokens', async () => {
+    const tokens = await sdk.swap.getAllTokens();
+
+    expect(Array.isArray(tokens)).toBe(true);
+    expect(tokens.length).toBeGreaterThan(0);
+    expect(tokens[0]).toEqual(
+      expect.objectContaining({
+        symbol: expect.any(String),
+        address: expect.any(String),
+        decimals: expect.any(Number),
+        name: expect.any(String),
+        network: expect.any(Number),
+      })
+    );
+    // Array.isArray instead of expect.any(Array): with the native fetch
+    // fetcher these arrays come from the host realm, so `instanceof Array`
+    // (which expect.any relies on) is false inside jest's sandbox
+    expect(Array.isArray(tokens[0]?.sources)).toBe(true);
+    expect(Array.isArray(tokens[0]?.categories)).toBe(true);
+
+    // API fields are mapped to the SDK Token shape, not passed through
+    expect(tokens[0]).not.toHaveProperty('chainId');
+    expect(tokens[0]).not.toHaveProperty('logoURI');
+
+    // /tokens/all is not scoped to the SDK chainId, tokens span networks
+    const networks = new Set(tokens.map((t) => t.network));
+    expect(networks.size).toBeGreaterThan(1);
+
+    // ipfs:// and ipns:// logo URIs are converted to http gateway URLs
+    for (const { img } of tokens) {
+      if (img) expect(img).not.toMatch(/^ip[fn]s:\/\//i);
+    }
+  });
+
   test('Get_Rates', async () => {
     const priceRoute = await sdk.swap.getRate({
       srcToken: ETH,

--- a/tests/simpleSdk.test.ts
+++ b/tests/simpleSdk.test.ts
@@ -92,10 +92,13 @@ describe.each([
         decimals: expect.any(Number),
         name: expect.any(String),
         network: expect.any(Number),
-        sources: expect.any(Array),
-        categories: expect.any(Array),
       })
     );
+    // Array.isArray instead of expect.any(Array): with the native fetch
+    // fetcher these arrays come from the host realm, so `instanceof Array`
+    // (which expect.any relies on) is false inside jest's sandbox
+    expect(Array.isArray(tokens[0]?.sources)).toBe(true);
+    expect(Array.isArray(tokens[0]?.categories)).toBe(true);
 
     // API fields are mapped to the SDK Token shape, not passed through
     expect(tokens[0]).not.toHaveProperty('chainId');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> `getTokens` changes endpoint and return shape (`ApiToken`), which can break integrators expecting the old `/tokens` response; balance helpers are only deprecated, not removed.
> 
> **Overview**
> **Curated token lists** move behind new `/fiat/tokens/*` endpoints and richer SDK types (10.2.0).
> 
> `getTokens` now calls **`/fiat/tokens/{chainId}`** (replacing `/tokens/{chainId}`), accepts optional **`category`** filtering, and returns **`ApiToken[]`** with `name`, `sources`, `categories`, `tags`, and `network` mapped from the list API. **`getAllTokens`** and **`getTokenCategories`** are added for cross-chain lists and category metadata.
> 
> Token logos from **`ipfs://` / `ipns://`** are rewritten to **`https://ipfs.io/...`** via new **`uriToHttpURL`**. **`getSpender`** gains **`getDelta()`**, returning the **`ParaswapDelta`** contract address or `null`. **`constructGetBalances`** is marked deprecated for a future major; **`getTokens(requestParams)`** as the sole first argument is deprecated in favor of **`getTokens({}, requestParams)`**.
> 
> Tests cover mapping, multi-network `getAllTokens`, and gateway URLs. Hardhat **`initialBaseFeePerGas`** is set to `0` for local forks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86f543c1acd2406245f334a9a1bb0e474113c5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->