### PR TITLE
fix: don't report a bogus minimal destAmount on bridge-and-swap routes

### DIFF
--- a/src/methods/delta/helpers/orders.ts
+++ b/src/methods/delta/helpers/orders.ts
@@ -352,6 +352,13 @@ function getExpectedTwapSrcAmount(
 
 /**
  * @description Returns the expected destination amount for a TWAP order.
+ *
+ * Note: on cross-chain **bridge-and-swap** routes the returned value is not
+ * denominated in the token the user is paid in — `bridge.scalingFactor` only
+ * converts decimals for same-asset bridge routes (see
+ * {@link getCrosschainMinimalDestAmount}). Unlike `getAuctionAmounts`, this
+ * getter reads the order struct alone and so has no expected output to validate
+ * against; prefer the auction envelope's `output` amounts where available.
  */
 function getExpectedTwapDestAmount(
   order:
@@ -391,6 +398,61 @@ function scaleByFactor(amount: bigint, scalingFactor = 0): bigint {
   return scalingFactor < 0
     ? amount / base ** BigInt(-scalingFactor)
     : amount * base ** BigInt(scalingFactor);
+}
+
+/**
+ * @description How far a genuine cross-chain minimum may deviate from the
+ * expected output before we stop trusting it. A same-asset bridge minimum and
+ * the expected output describe the *same asset*, so they differ only by
+ * slippage and bridge fees — well inside this band in either direction.
+ * A mismatch beyond it means the two values are denominated in different
+ * assets, which is off by at least the gap between their decimals (>= 100x in
+ * practice, and typically 1e10–1e12).
+ */
+const MAX_PLAUSIBLE_MINIMUM_DEVIATION = 100n;
+
+/**
+ * @description Returns the minimal dest amount for a cross-chain order, or
+ * `undefined` when it cannot be derived from the order struct.
+ *
+ * `order.destAmount` is denominated in `order.destToken` — the token received
+ * on the *source* chain — while the user is ultimately paid in
+ * `bridge.outputToken` on the destination chain. `bridge.scalingFactor`
+ * (`destDecimals - srcDecimals`) converts between the two, but only on
+ * **same-asset** bridge routes, where they are the same asset differing only in
+ * decimals.
+ *
+ * On **bridge-and-swap** routes (e.g. Mayan or Relay quoting USDC on Optimism
+ * to native BNB on BSC) they are entirely different assets, so no decimal
+ * factor can convert one into the other. The backend sets `scalingFactor: 0`
+ * there to mark it inapplicable, and the real floor is the bridge protocol's
+ * own `minAmountOut`, encoded inside `bridge.protocolData` — which this SDK
+ * does not decode.
+ *
+ * The auction envelope carries no flag separating the two route kinds, so
+ * instead of trusting the scaling blindly we validate its result against the
+ * expected output and report no minimum when the assumption clearly does not
+ * hold. Reporting `undefined` lets callers fall back to the expected amount,
+ * rather than rendering a figure that is wrong by orders of magnitude.
+ */
+function getCrosschainMinimalDestAmount(
+  order: Pick<DeltaAuctionOrder, 'destAmount'> & { bridge: Bridge },
+  expectedDestAmount: string
+): string | undefined {
+  const scaled = scaleByFactor(
+    BigInt(order.destAmount),
+    order.bridge.scalingFactor
+  );
+  const expected = BigInt(expectedDestAmount);
+
+  // No expected output to validate against (e.g. a not-yet-priced order).
+  if (expected === 0n) return scaled.toString();
+
+  const plausible =
+    scaled * MAX_PLAUSIBLE_MINIMUM_DEVIATION >= expected &&
+    scaled <= expected * MAX_PLAUSIBLE_MINIMUM_DEVIATION;
+
+  return plausible ? scaled.toString() : undefined;
 }
 
 ///// GETTERS — auction envelope (v2) //////
@@ -510,6 +572,9 @@ function getExecutedAmount(side: DeltaTokenSide, fallback: string): string {
  * @description Returns expected and minimal amounts and, once the auction is completed,
  * executed amounts. Executed amounts prefer the `executedAmount` baked onto the
  * token sides and fall back to summing transactions.
+ *
+ * `minimal.destAmount` is `undefined` when no minimum can be derived — see
+ * {@link getCrosschainMinimalDestAmount}.
  */
 function getAuctionAmounts(
   auction: Pick<
@@ -530,10 +595,7 @@ function getAuctionAmounts(
   } else if (isOrderCrosschain(order)) {
     minimal = {
       srcAmount: order.srcAmount,
-      destAmount: scaleByFactor(
-        BigInt(order.destAmount),
-        order.bridge.scalingFactor
-      ).toString(),
+      destAmount: getCrosschainMinimalDestAmount(order, expected.destAmount),
     };
   } else {
     minimal = {

--- a/src/methods/delta/helpers/types.ts
+++ b/src/methods/delta/helpers/types.ts
@@ -223,7 +223,13 @@ export type UnifiedDeltaOrderData = {
     /** @description  minimal amounts that user should receive if the order is filled, known at the start of Order execution */
     minimal: {
       srcAmount: string;
-      destAmount: string;
+      /** @description  `undefined` when no minimum can be derived. This happens on
+       * cross-chain **bridge-and-swap** routes, where the order's `destAmount` is
+       * denominated in a different asset than the token the user is paid in and
+       * `bridge.scalingFactor` cannot convert between the two — the floor for those routes
+       * lives in the bridge protocol's own `minAmountOut` inside `bridge.protocolData`.
+       * Fall back to `amounts.expected.destAmount` when absent. */
+      destAmount: string | undefined;
     };
     /** @description  final amounts after Order execution. May be less than expected if there is slippage or only partial execution was achieved */
     final?: {

--- a/tests/deltaOrderAmounts.test.ts
+++ b/tests/deltaOrderAmounts.test.ts
@@ -1,0 +1,191 @@
+import { OrderHelpers } from '../src';
+import type { Bridge, DeltaAuctionOrder } from '../src';
+
+const { getAuctionAmounts } = OrderHelpers.getters;
+
+const NO_BRIDGE: Bridge = {
+  protocolSelector: '0x00000000',
+  destinationChainId: 0,
+  outputToken: '0x0000000000000000000000000000000000000000',
+  scalingFactor: 0,
+  protocolData: '0x',
+};
+
+const baseOrder: DeltaAuctionOrder = {
+  owner: '0x4fbb11b908dfaaeddf30454436314801f8d91a83',
+  beneficiary: '0x4fbb11b908dfaaeddf30454436314801f8d91a83',
+  srcToken: '0x0b2c639c533813f4aa9d7837caf62653d097ff85',
+  destToken: '0x0b2c639c533813f4aa9d7837caf62653d097ff85',
+  srcAmount: '1597481',
+  destAmount: '1588804',
+  expectedAmount: '1596788',
+  kind: 0,
+  metadata: '0x',
+  deadline: 1785141849,
+  nonce: '1',
+  permit: '0x',
+  partnerAndFee: '512',
+  bridge: NO_BRIDGE,
+};
+
+type AuctionInput = Parameters<typeof getAuctionAmounts>[0];
+
+function makeAuction({
+  order,
+  destChainId,
+  destToken,
+  expectedDestAmount,
+}: {
+  order: DeltaAuctionOrder;
+  destChainId: number;
+  destToken: string;
+  expectedDestAmount: string | null;
+}): AuctionInput {
+  return {
+    status: 'PENDING',
+    order,
+    input: {
+      chainId: 10,
+      token: order.srcToken,
+      amount: order.srcAmount,
+    },
+    output: {
+      chainId: destChainId,
+      token: destToken,
+      expectedAmount: expectedDestAmount,
+      executedAmount: null,
+    },
+    transactions: [],
+  } as AuctionInput;
+}
+
+describe('getAuctionAmounts — minimal.destAmount', () => {
+  it('leaves the minimum unscaled for same-chain orders', () => {
+    const auction = makeAuction({
+      order: baseOrder,
+      destChainId: 10,
+      destToken: baseOrder.destToken,
+      expectedDestAmount: '1596788',
+    });
+
+    expect(getAuctionAmounts(auction).minimal.destAmount).toBe('1588804');
+  });
+
+  it('scales the minimum into dest-chain decimals for a same-asset bridge route', () => {
+    // USDC 6 decimals on Optimism -> USDC 18 decimals on BSC: scalingFactor +12.
+    const auction = makeAuction({
+      order: {
+        ...baseOrder,
+        bridge: {
+          ...NO_BRIDGE,
+          protocolSelector: '0x12345678',
+          destinationChainId: 56,
+          outputToken: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+          scalingFactor: 12,
+        },
+      },
+      destChainId: 56,
+      destToken: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+      expectedDestAmount: '1596788000000000000',
+    });
+
+    expect(getAuctionAmounts(auction).minimal.destAmount).toBe(
+      '1588804000000000000'
+    );
+  });
+
+  it('keeps the minimum when a same-asset bridge route needs no scaling', () => {
+    // USDC 6 decimals on both sides: scalingFactor 0 is correct here.
+    const auction = makeAuction({
+      order: {
+        ...baseOrder,
+        bridge: {
+          ...NO_BRIDGE,
+          protocolSelector: '0x12345678',
+          destinationChainId: 8453,
+          outputToken: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+          scalingFactor: 0,
+        },
+      },
+      destChainId: 8453,
+      destToken: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      expectedDestAmount: '1594000',
+    });
+
+    expect(getAuctionAmounts(auction).minimal.destAmount).toBe('1588804');
+  });
+
+  it('reports no minimum for a bridge-and-swap route', () => {
+    // Real order 97264d36-382a-4965-b205-54eefdf7fccb: USDC on Optimism (6 dec)
+    // swapped to native BNB on BSC (18 dec) via Mayan. `destAmount` is USDC and
+    // `scalingFactor` is 0 by design, so the scaled value (1588804 wei of BNB,
+    // ~0 BNB) is meaningless as a minimum. The real floor is `minAmountOut`
+    // inside `bridge.protocolData`.
+    const auction = makeAuction({
+      order: {
+        ...baseOrder,
+        bridge: {
+          ...NO_BRIDGE,
+          protocolSelector: '0x66ad5736',
+          destinationChainId: 56,
+          outputToken: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          scalingFactor: 0,
+        },
+      },
+      destChainId: 56,
+      destToken: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      expectedDestAmount: '2751220017546070',
+    });
+
+    const { minimal, expected } = getAuctionAmounts(auction);
+
+    expect(minimal.destAmount).toBeUndefined();
+    // the expected amount stays intact and usable as a fallback
+    expect(expected.destAmount).toBe('2751220017546070');
+  });
+
+  it('reports no minimum when scaling overshoots the expected output', () => {
+    // Inverse denomination mismatch: an 18 decimal source token swapped into an
+    // 8 decimal output token would put the "minimum" far above the real output.
+    const auction = makeAuction({
+      order: {
+        ...baseOrder,
+        destAmount: '7376781108121617553',
+        bridge: {
+          ...NO_BRIDGE,
+          protocolSelector: '0x66ad5736',
+          destinationChainId: 8453,
+          outputToken: '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
+          scalingFactor: 0,
+        },
+      },
+      destChainId: 8453,
+      destToken: '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
+      expectedDestAmount: '6800',
+    });
+
+    expect(getAuctionAmounts(auction).minimal.destAmount).toBeUndefined();
+  });
+
+  it('falls back to the scaled value when the auction carries no expected output', () => {
+    const auction = makeAuction({
+      order: {
+        ...baseOrder,
+        bridge: {
+          ...NO_BRIDGE,
+          protocolSelector: '0x12345678',
+          destinationChainId: 56,
+          outputToken: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+          scalingFactor: 12,
+        },
+      },
+      destChainId: 56,
+      destToken: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+      expectedDestAmount: null,
+    });
+
+    expect(getAuctionAmounts(auction).minimal.destAmount).toBe(
+      '1588804000000000000'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`OrderHelpers.getters.getAuctionAmounts` reported a `minimal.destAmount` that is wrong by orders of magnitude on cross-chain **bridge-and-swap** routes. This makes the SDK stop fabricating that number when it cannot be derived, and adds unit tests covering both route kinds.

Reported by the front-end team as *"`scalingFactor` is `0` even though the dest token is BNB with 18 decimals"* on order [`97264d36-382a-4965-b205-54eefdf7fccb`](https://api.velora.xyz/v2/delta/orders/97264d36-382a-4965-b205-54eefdf7fccb). The investigation below shows `scalingFactor: 0` is correct on the relayer side, and the bug is here in the SDK's display math.

## The bug

`src/methods/delta/helpers/orders.ts` computed the cross-chain minimum as:

```ts
} else if (isOrderCrosschain(order)) {
  minimal = {
    srcAmount: order.srcAmount,
    destAmount: scaleByFactor(BigInt(order.destAmount), order.bridge.scalingFactor).toString(),
  };
}
```

`order.destAmount` is denominated in `order.destToken` — the token received on the **source** chain — while the user is ultimately paid in `bridge.outputToken` on the destination chain. `bridge.scalingFactor` (`destDecimals - srcDecimals`) converts between the two, but **only when they are the same asset differing in decimals**.

`isOrderCrosschain` (`orders.ts:257`) only checks `bridge.destinationChainId !== 0`, so it cannot tell the two route kinds apart:

| Route kind | `order.destToken` vs `bridge.outputToken` | `scalingFactor` | Is scaling valid? |
|---|---|---|---|
| Same-asset bridge | same asset, different chain | `destDecimals - srcDecimals` | ✅ yes |
| Bridge-and-swap (Mayan / Relay) | **different assets** | `0` — marked inapplicable | ❌ no conversion exists |

## What the UI rendered for the reported order

The order is USDC on Optimism (6 dec) → native BNB on BSC (18 dec) via Mayan:

| | value | as BNB (18 dec) |
|---|---|---|
| `minimal.destAmount` (before this PR) | `1588804` | **0.0000000000015888 BNB** ← "min received" showed as ~0 |
| `expected` / `executed` | `2751220017546070` | 0.00275122 BNB ✅ correct |
| True floor (Mayan `minAmountOut`) | `2744340000000000` | 0.00274434 BNB |

Note that forcing `scalingFactor` to `12` — the fix originally requested — would render `1588804 × 10^12` = **1.5888 BNB** as the minimum against 0.00275 BNB actually received: a phantom 99.8% shortfall. The field genuinely cannot express this route in either direction.

## Why `scalingFactor: 0` is correct on the relayer

<details>
<summary>Relayer + contract trace</summary>

**Relayer** — `trade-relayer/src/lib/bridge/mayan/mayan.ts:312` (same pattern at `relay/relay.ts:537`):

```ts
scalingFactor: isSwap ? 0 : (request.scalingFactor ?? 0),
```

The original commit spelled out the intent: `scalingFactor: 0, // not relevant for swap quotes`. For same-asset routes it is computed at `bridge-api.ts:840`/`:973` as `destTokenDecimals - decimals`, matching the contract's definition.

**Contract** — `portikus-contracts/src/modules/bridge/base/BridgeModuleBase.sol:77`:

```
/// @dev scalingFactor = destDecimals - srcDecimals
```

In `MayanBridgeModule.sol`, `scalingFactor` is used in exactly one place — event emission:

```solidity
uint256 outputAmount = _convertToDestDecimals(ctx.amount, ctx.scalingFactor);
emit TokensBridged(ctx.orderHash, ctx.beneficiary, ctx.destChainId, ctx.amount, outputAmount, "mayan-swift");
```

Nothing on-chain enforces it for Mayan, and the relayer has no `TokensBridged` consumer (Mayan fills are read from the Mayan explorer's `toAmount64`). That is why the user received the correct amount despite `scalingFactor: 0`.

**Where the real floor lives** — decoding `bridge.protocolData` of the reported order:

```
mayanSwift           0x40ffe85a28dc9993541449464d7529a922142960
wormholeDestChainId  4       (BSC)
minAmountOut         274434  (Wormhole 8-dec normalization -> 0.00274434 BNB)
gasDrop / cancelFee / refundFee   0 / 2986 / 1344
deadline             1785142546
referrer             0x81037e7bE71bCE9591De0c54BB485aD3e048B8DE, 0 bps
auctionMode          2 (ENGLISH)
```

Received 0.00275122 BNB ≥ min 0.00274434 BNB ✅ — 0.25% above the floor, which is what a correct UI would show.

</details>

## The fix

The auction envelope (`DeltaTokenSide` / `DeltaAuction`) exposes no `isSwap` flag, no route metadata, and no authoritative minimum — and `scalingFactor: 0` is ambiguous, meaning both *"same asset, equal decimals"* (where the raw `destAmount` **is** the correct minimum, e.g. USDC 6 dec Optimism → USDC 6 dec Base) and *"not applicable"*. So the SDK cannot detect the route kind directly.

Instead, `getCrosschainMinimalDestAmount` validates the scaled result against the expected output and reports `undefined` when the scaling assumption clearly does not hold:

```ts
const plausible =
  scaled * MAX_PLAUSIBLE_MINIMUM_DEVIATION >= expected &&
  scaled <= expected * MAX_PLAUSIBLE_MINIMUM_DEVIATION;
```

Rationale for the `100x` band: a same-asset bridge minimum and the expected output describe the *same asset*, so they differ only by slippage and bridge fees — comfortably inside the band in either direction. An asset-denomination mismatch is off by at least the gap between the two tokens' decimals (≥ 100× in practice, typically 1e10–1e12), amplified further by the price ratio between the two assets.

This keeps every same-asset bridge route working, including the common equal-decimals case, and only drops values that are provably nonsense.

### Note for reviewers: deviation from a strict upper bound

An earlier sketch of this guard used `scaled <= expected` on the grounds that a minimum can never exceed the expected output. That is **not** actually safe: `destAmount` is the floor *before* the bridge runs, while `expected.destAmount` is the estimate *after* bridge fees, so on small trades with a fixed relayer fee a legitimate minimum can sit slightly above the expected output. The symmetric band avoids silently dropping those.

## API change

`amounts.minimal.destAmount` is now `string | undefined` — a breaking type change for TypeScript consumers. Callers should fall back to `amounts.expected.destAmount`; the JSDoc on `UnifiedDeltaOrderData` says so explicitly.

There is no runtime behavior change for same-chain orders or for same-asset bridge routes.

## Also documented (no behavior change)

`getExpectedTwapDestAmount` (`orders.ts:356`, exported via `OrderHelpers.getters`) has the same defect for cross-chain TWAP bridge-and-swap routes, but it reads the order struct alone and so has no expected output to validate against. It now carries a JSDoc warning pointing callers at the auction envelope's `output` amounts.

## Follow-up (relayer side, not in this PR)

The clean long-term fix belongs in the relayer, which is the only component that knows both branches: expose an authoritative minimum on the output side of the quote/order response (e.g. `destination.output.minAmount` / `output.minAmount`), computed as the scaled `destAmount` for same-asset bridges and the protocol-specific floor (`minAmountOut` for Mayan, its Relay equivalent) for swap routes. Each `BridgeProvider` already builds `protocolData` and has the number in hand. Exposing `isSwap` (or a `swap` bridge tag in `price-mapper.ts`, which today only emits `recommended`/`fastest`/`best-return`) would also let the SDK drop this heuristic entirely.

Two smaller relayer findings from the same investigation, worth separate tickets:
- The `TokensBridged` event emits a meaningless `outputAmount` on bridge-and-swap routes. Cosmetic — no consumer today.
- `enum AuctionMode { Bypass = 0, English = 1 }` (`mayan.ts:82`) does not match the on-chain enum (`NONE=0, BYPASS=1, ENGLISH=2`). Harmless today because the value flows through from the Mayan SDK (`2` here, correct), but anyone constructing a value from that enum would produce an order reverting with `InvalidAuctionMode`.

## Verification

- `npx dts test deltaOrderAmounts` — 6 tests pass, covering: same-chain, same-asset bridge with `scalingFactor: 12`, same-asset bridge with `scalingFactor: 0` (equal decimals), the reported bridge-and-swap order, the inverse overshoot direction (18 dec → 8 dec), and the missing-`expectedAmount` fallback.
- `npx tsc --noEmit` clean, `npx dts lint src` clean, `npx dts build` succeeds.

`docs/md` is generated (`pnpm docs` embeds the current branch name in links), so it is intentionally not regenerated here — worth doing on `master` at release time to pick up the new JSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes amount semantics and a public TypeScript type for integrators displaying min-received; logic is localized to cross-chain minimum derivation with tests, but consumers must handle `undefined`.
> 
> **Overview**
> Fixes **`getAuctionAmounts`** reporting a **minimal destination amount** that was wrong by orders of magnitude on cross-chain **bridge-and-swap** routes (e.g. USDC → native BNB), where `order.destAmount` and `bridge.scalingFactor` apply to a different asset than the user’s payout token.
> 
> **`getCrosschainMinimalDestAmount`** still scales `destAmount` for same-asset bridges, but compares the result to **`expected.destAmount`** with a **100×** plausibility band; implausible values return **`undefined`** so UIs can fall back to the expected output instead of showing ~0 BNB. When expected output is missing (`0`), behavior keeps returning the scaled value.
> 
> **`UnifiedDeltaOrderData.amounts.minimal.destAmount`** is now **`string | undefined`** (breaking for TypeScript consumers). JSDoc on **`getExpectedTwapDestAmount`** warns about the same limitation on TWAP cross-chain swap routes without changing its behavior.
> 
> Adds **`tests/deltaOrderAmounts.test.ts`** covering same-chain, same-asset bridge (with/without scaling), bridge-and-swap, overshoot mismatch, and missing expected output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc95a8c997d1e0439e997a5ce302da2616f82b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->