### PR TITLE
Fix/delta min amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/methods/delta/helpers/orders.ts
+++ b/src/methods/delta/helpers/orders.ts
@@ -240,7 +240,7 @@ function isPendingAuction<T extends Pick<DeltaAuction, 'status'>>(
  * between 0 and 100.
  */
 function isPartiallyExecutedAuction<
-  T extends Pick<DeltaAuction, 'order' | 'transactions'>
+  T extends Pick<DeltaAuction, 'order' | 'transactions'>,
 >(
   auction: T
 ): auction is T & { transactions: NonEmptyArray<DeltaTransaction> } {
@@ -355,17 +355,13 @@ function getExpectedTwapSrcAmount(
  */
 function getExpectedTwapDestAmount(
   order:
-    | Pick<TWAPDeltaOrder, 'destAmountPerSlice' | 'numSlices' | 'bridge'>
-    | Pick<TWAPBuyDeltaOrder, 'totalDestAmount' | 'bridge'>
+    | Pick<TWAPDeltaOrder, 'destAmountPerSlice' | 'numSlices'>
+    | Pick<TWAPBuyDeltaOrder, 'totalDestAmount'>
 ) {
   const destAmount =
     'destAmountPerSlice' in order
       ? BigInt(order.destAmountPerSlice) * BigInt(order.numSlices) // SELL
       : BigInt(order.totalDestAmount); // BUY
-
-  if (isOrderCrosschain(order)) {
-    return scaleByFactor(destAmount, order.bridge.scalingFactor).toString();
-  }
 
   return destAmount.toString();
 }
@@ -379,18 +375,6 @@ function getExpectedTwapOrderAmounts(
   const srcAmount = getExpectedTwapSrcAmount(order);
   const destAmount = getExpectedTwapDestAmount(order);
   return { srcAmount, destAmount };
-}
-
-function scaleByFactor(amount: bigint, scalingFactor = 0): bigint {
-  if (!amount) return 0n;
-
-  if (scalingFactor === 0) return amount;
-
-  const base = 10n;
-
-  return scalingFactor < 0
-    ? amount / base ** BigInt(-scalingFactor)
-    : amount * base ** BigInt(scalingFactor);
 }
 
 ///// GETTERS — auction envelope (v2) //////
@@ -524,23 +508,14 @@ function getAuctionAmounts(
 
   const order = auction.order;
 
-  let minimal;
-  if (isTWAPOrder(order)) {
-    minimal = expected; // TWAP doesn't carry explicit min amounts
-  } else if (isOrderCrosschain(order)) {
-    minimal = {
-      srcAmount: order.srcAmount,
-      destAmount: scaleByFactor(
-        BigInt(order.destAmount),
-        order.bridge.scalingFactor
-      ).toString(),
-    };
-  } else {
-    minimal = {
-      srcAmount: order.srcAmount,
-      destAmount: order.destAmount,
-    };
-  }
+  const minimal =
+    isTWAPOrder(order) || isOrderCrosschain(order)
+      ? // TWAP and crosschain orders don't carry explicit min amounts
+        expected
+      : {
+          srcAmount: order.srcAmount,
+          destAmount: order.destAmount,
+        };
 
   if (!isCompletedAuction(auction)) {
     return { expected, minimal };

--- a/src/methods/delta/helpers/orders.ts
+++ b/src/methods/delta/helpers/orders.ts
@@ -240,7 +240,7 @@ function isPendingAuction<T extends Pick<DeltaAuction, 'status'>>(
  * between 0 and 100.
  */
 function isPartiallyExecutedAuction<
-  T extends Pick<DeltaAuction, 'order' | 'transactions'>,
+  T extends Pick<DeltaAuction, 'order' | 'transactions'>
 >(
   auction: T
 ): auction is T & { transactions: NonEmptyArray<DeltaTransaction> } {


### PR DESCRIPTION
For crosschain orders with swap on the destination chain, there is no way to calculate the minimal destAmount.
Scaling by factor doesn't work if, for ex:
**USDC Base -> BNB Binance**

**USDC Base** bridged to **USDC Binance**
**USDC Binance** swaped to **BNB Binance**

order.destAmount = USDC amount
no matter what value is in bridge.scalingFactor, no way to calculate amount for a completely different token (USDC!=BNB)

Temp solution: use expected amount as minimal for all crosschain orders

part of FRNT-1378

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes amount semantics for crosschain and TWAP minimal/expected helpers, which integrators may rely on for slippage or display; scope is limited to delta order helpers.
> 
> **Overview**
> Fixes incorrect **minimal destination amounts** for Delta crosschain flows where the destination token differs from the bridged asset (e.g. USDC bridged then swapped to BNB). **`bridge.scalingFactor`** could not represent that case when `order.destAmount` stayed in the source/bridge token units.
> 
> **`getAuctionAmounts`** now treats crosschain orders like TWAP: **`minimal`** comes from the auction envelope’s **expected** `input`/`output` amounts instead of on-chain `srcAmount`/`destAmount` with scaled `destAmount`. TWAP expected dest math no longer applies bridge scaling, and the unused **`scaleByFactor`** helper is removed. Package version bumps to **10.2.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df0ada194ba8fcf6dab0ca6301a65a83f7696f07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->